### PR TITLE
fix: address CodeQL findings in collector + sinks

### DIFF
--- a/HoneyDrunk.Pulse/HoneyDrunk.Pulse.Sample.Worker/Worker.cs
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Pulse.Sample.Worker/Worker.cs
@@ -72,7 +72,7 @@ public sealed partial class Worker(ILogger<Worker> logger, IAnalyticsEmitter ana
                 // Graceful shutdown
                 break;
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 LogJobError(ex, _jobCounter);
                 activity?.SetStatus(ActivityStatusCode.Error, ex.Message);

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.OpenTelemetry/PulseAnalyticsEmitter.cs
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.OpenTelemetry/PulseAnalyticsEmitter.cs
@@ -89,7 +89,7 @@ public sealed partial class PulseAnalyticsEmitter(
             // Graceful shutdown
             throw;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             LogUnexpectedError(ex, eventsList.Count);
         }

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.OpenTelemetry/PulseAnalyticsEmitter.cs
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.OpenTelemetry/PulseAnalyticsEmitter.cs
@@ -89,8 +89,10 @@ public sealed partial class PulseAnalyticsEmitter(
             // Graceful shutdown
             throw;
         }
-        catch (Exception ex) when (ex is not OperationCanceledException)
+        catch (Exception ex) when (ex is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
         {
+            // HttpClient timeouts surface as TaskCanceledException with the token NOT cancelled —
+            // those should be treated as recoverable send failures, not propagated as cancellation.
             LogUnexpectedError(ex, eventsList.Count);
         }
     }

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.AzureMonitor/Implementation/AzureMonitorSink.cs
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.AzureMonitor/Implementation/AzureMonitorSink.cs
@@ -128,7 +128,7 @@ public sealed partial class AzureMonitorSink(
             // The actual export happens through the OpenTelemetry SDK exporter pipeline
             LogDataReceived(signalType, contentType, data.Length);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             LogExportFailed(signalType, ex.Message);
         }

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.PostHog/Implementation/PostHogSink.cs
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.PostHog/Implementation/PostHogSink.cs
@@ -158,8 +158,10 @@ public sealed partial class PostHogSink : IAnalyticsSink, IDisposable
 
             LogEventsSent(eventsToSend.Count);
         }
-        catch (Exception ex) when (ex is not OperationCanceledException)
+        catch (Exception ex) when (ex is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
         {
+            // HttpClient timeouts surface as TaskCanceledException with the token NOT cancelled —
+            // those should re-queue for the next flush, not propagate as cancellation.
             LogSendFailed(ex, eventsToSend.Count);
 
             // Re-add events that failed to send

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.PostHog/Implementation/PostHogSink.cs
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.PostHog/Implementation/PostHogSink.cs
@@ -158,7 +158,7 @@ public sealed partial class PostHogSink : IAnalyticsSink, IDisposable
 
             LogEventsSent(eventsToSend.Count);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             LogSendFailed(ex, eventsToSend.Count);
 

--- a/HoneyDrunk.Pulse/Pulse.Collector/Endpoints/OtlpEndpoints.cs
+++ b/HoneyDrunk.Pulse/Pulse.Collector/Endpoints/OtlpEndpoints.cs
@@ -95,7 +95,7 @@ public static class OtlpEndpoints
                 ErrorCount = result.ErrorSpans.Count,
             });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogTracesRequestError(ex);
             return Results.Problem("Error processing traces", statusCode: 500);
@@ -136,7 +136,7 @@ public static class OtlpEndpoints
 
             return Results.Ok(new { Status = "accepted", result.MetricCount, result.DataPointCount });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogMetricsRequestError(ex);
             return Results.Problem("Error processing metrics", statusCode: 500);
@@ -185,7 +185,7 @@ public static class OtlpEndpoints
                 ErrorLogCount = result.ErrorLogs.Count,
             });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogLogsRequestError(ex);
             return Results.Problem("Error processing logs", statusCode: 500);
@@ -250,7 +250,7 @@ public static class OtlpEndpoints
             logger.LogAnalyticsInvalidJson(ex);
             return Results.BadRequest(new { Error = "Invalid JSON format" });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogAnalyticsRequestError(ex);
             return Results.Problem("Error processing analytics events", statusCode: 500);
@@ -309,7 +309,7 @@ public static class OtlpEndpoints
             logger.LogErrorReportInvalidJson(ex);
             return Results.BadRequest(new { Error = "Invalid JSON format" });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogErrorReportRequestError(ex);
             return Results.Problem("Error processing error report", statusCode: 500);

--- a/HoneyDrunk.Pulse/Pulse.Collector/Ingestion/IngestionPipeline.cs
+++ b/HoneyDrunk.Pulse/Pulse.Collector/Ingestion/IngestionPipeline.cs
@@ -318,7 +318,7 @@ public sealed partial class IngestionPipeline(
                 {
                     await analyticsSink.CaptureBatchAsync(eventList, cancellationToken).ConfigureAwait(false);
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is not OperationCanceledException)
                 {
                     LogAnalyticsSinkForwardingFailed(ex);
                     sinkFailures++;
@@ -385,7 +385,7 @@ public sealed partial class IngestionPipeline(
 
             LogErrorEventProcessed(errorEvent.Message ?? "Exception");
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             LogSentryRoutingError(ex);
             CollectorTelemetry.RecordError("sentry_routing");
@@ -425,7 +425,7 @@ public sealed partial class IngestionPipeline(
             {
                 await sink.ExportAsync(data, contentType, cancellationToken).ConfigureAwait(false);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 LogTraceSinkForwardingFailed(ex);
                 failures++;
@@ -452,7 +452,7 @@ public sealed partial class IngestionPipeline(
             {
                 await sink.ExportAsync(data, contentType, cancellationToken).ConfigureAwait(false);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 LogMetricsSinkForwardingFailed(ex);
                 failures++;
@@ -491,7 +491,7 @@ public sealed partial class IngestionPipeline(
 
                 await sink.ExportAsync(data, contentType, cancellationToken).ConfigureAwait(false);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 LogLogsSinkForwardingFailed(ex);
                 failures++;
@@ -568,7 +568,7 @@ public sealed partial class IngestionPipeline(
         {
             await publisher.PublishAsync(ingestionEvent, cancellationToken).ConfigureAwait(false);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             LogTransportPublishFailed(ex, sourceName);
             CollectorTelemetry.RecordError("transport_publish");
@@ -644,7 +644,7 @@ public sealed partial class IngestionPipeline(
 
                 LogErrorSpanForwarded(errorSpan.SpanName, errorSpan.ServiceName ?? "unknown");
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 LogErrorSpanForwardingFailed(ex, errorSpan.SpanName);
             }
@@ -724,7 +724,7 @@ public sealed partial class IngestionPipeline(
 
                 LogErrorLogForwarded(errorLog.SeverityText ?? "ERROR", sourceName ?? errorLog.ServiceName ?? "unknown");
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 LogErrorLogForwardingFailed(ex, errorLog.Message ?? "Error log");
             }

--- a/HoneyDrunk.Pulse/Pulse.Collector/Ingestion/IngestionPipeline.cs
+++ b/HoneyDrunk.Pulse/Pulse.Collector/Ingestion/IngestionPipeline.cs
@@ -318,7 +318,7 @@ public sealed partial class IngestionPipeline(
                 {
                     await analyticsSink.CaptureBatchAsync(eventList, cancellationToken).ConfigureAwait(false);
                 }
-                catch (Exception ex) when (ex is not OperationCanceledException)
+                catch (Exception ex) when (ex is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
                 {
                     LogAnalyticsSinkForwardingFailed(ex);
                     sinkFailures++;
@@ -385,7 +385,7 @@ public sealed partial class IngestionPipeline(
 
             LogErrorEventProcessed(errorEvent.Message ?? "Exception");
         }
-        catch (Exception ex) when (ex is not OperationCanceledException)
+        catch (Exception ex) when (ex is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
         {
             LogSentryRoutingError(ex);
             CollectorTelemetry.RecordError("sentry_routing");
@@ -425,7 +425,7 @@ public sealed partial class IngestionPipeline(
             {
                 await sink.ExportAsync(data, contentType, cancellationToken).ConfigureAwait(false);
             }
-            catch (Exception ex) when (ex is not OperationCanceledException)
+            catch (Exception ex) when (ex is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
             {
                 LogTraceSinkForwardingFailed(ex);
                 failures++;
@@ -452,7 +452,7 @@ public sealed partial class IngestionPipeline(
             {
                 await sink.ExportAsync(data, contentType, cancellationToken).ConfigureAwait(false);
             }
-            catch (Exception ex) when (ex is not OperationCanceledException)
+            catch (Exception ex) when (ex is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
             {
                 LogMetricsSinkForwardingFailed(ex);
                 failures++;
@@ -491,7 +491,7 @@ public sealed partial class IngestionPipeline(
 
                 await sink.ExportAsync(data, contentType, cancellationToken).ConfigureAwait(false);
             }
-            catch (Exception ex) when (ex is not OperationCanceledException)
+            catch (Exception ex) when (ex is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
             {
                 LogLogsSinkForwardingFailed(ex);
                 failures++;
@@ -568,7 +568,7 @@ public sealed partial class IngestionPipeline(
         {
             await publisher.PublishAsync(ingestionEvent, cancellationToken).ConfigureAwait(false);
         }
-        catch (Exception ex) when (ex is not OperationCanceledException)
+        catch (Exception ex) when (ex is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
         {
             LogTransportPublishFailed(ex, sourceName);
             CollectorTelemetry.RecordError("transport_publish");
@@ -644,7 +644,7 @@ public sealed partial class IngestionPipeline(
 
                 LogErrorSpanForwarded(errorSpan.SpanName, errorSpan.ServiceName ?? "unknown");
             }
-            catch (Exception ex) when (ex is not OperationCanceledException)
+            catch (Exception ex) when (ex is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
             {
                 LogErrorSpanForwardingFailed(ex, errorSpan.SpanName);
             }
@@ -724,7 +724,7 @@ public sealed partial class IngestionPipeline(
 
                 LogErrorLogForwarded(errorLog.SeverityText ?? "ERROR", sourceName ?? errorLog.ServiceName ?? "unknown");
             }
-            catch (Exception ex) when (ex is not OperationCanceledException)
+            catch (Exception ex) when (ex is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
             {
                 LogErrorLogForwardingFailed(ex, errorLog.Message ?? "Error log");
             }

--- a/HoneyDrunk.Pulse/Pulse.Collector/Ingestion/OtlpParser.cs
+++ b/HoneyDrunk.Pulse/Pulse.Collector/Ingestion/OtlpParser.cs
@@ -71,7 +71,7 @@ public sealed partial class OtlpParser(ILogger<OtlpParser> logger)
 
             return new OtlpTraceResult(estimatedSpanCount, resourceNames, errorSpans);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             LogTraceParseError(ex);
             return OtlpTraceResult.Empty;
@@ -119,7 +119,7 @@ public sealed partial class OtlpParser(ILogger<OtlpParser> logger)
 
             return new OtlpTraceResult(spanCount, [.. resourceNames], errorSpans);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             LogTraceParseError(ex);
             return OtlpTraceResult.Empty;
@@ -156,7 +156,7 @@ public sealed partial class OtlpParser(ILogger<OtlpParser> logger)
 
             return new OtlpMetricsResult(estimatedMetricCount, estimatedDataPointCount, resourceNames);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             LogMetricParseError(ex);
             return OtlpMetricsResult.Empty;
@@ -198,7 +198,7 @@ public sealed partial class OtlpParser(ILogger<OtlpParser> logger)
 
             return new OtlpLogsResult(estimatedLogCount, resourceNames, errorLogs, maxSeverity);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             LogLogParseError(ex);
             return OtlpLogsResult.Empty;
@@ -254,7 +254,7 @@ public sealed partial class OtlpParser(ILogger<OtlpParser> logger)
 
             return new OtlpLogsResult(logCount, [.. resourceNames], errorLogs, maxSeverity);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             LogLogParseError(ex);
             return OtlpLogsResult.Empty;
@@ -447,16 +447,13 @@ public sealed partial class OtlpParser(ILogger<OtlpParser> logger)
             {
                 if (attr.TryGetProperty("key", out var key) &&
                     key.GetString()?.Equals("service.name", StringComparison.OrdinalIgnoreCase) == true &&
-                    attr.TryGetProperty("value", out var value))
+                    attr.TryGetProperty("value", out var value) &&
+                    value.TryGetProperty("stringValue", out var stringValue))
                 {
-                    // OTLP attribute values can be in different formats
-                    if (value.TryGetProperty("stringValue", out var stringValue))
+                    var serviceName = stringValue.GetString();
+                    if (!string.IsNullOrWhiteSpace(serviceName))
                     {
-                        var serviceName = stringValue.GetString();
-                        if (!string.IsNullOrWhiteSpace(serviceName))
-                        {
-                            names.Add(serviceName);
-                        }
+                        names.Add(serviceName);
                     }
                 }
             }
@@ -714,22 +711,18 @@ public sealed partial class OtlpParser(ILogger<OtlpParser> logger)
 
         // Get message from body
         string? message = null;
-        if (logRecord.TryGetProperty("body", out var body))
+        if (logRecord.TryGetProperty("body", out var body) &&
+            body.TryGetProperty("stringValue", out var strVal))
         {
-            if (body.TryGetProperty("stringValue", out var strVal))
-            {
-                message = strVal.GetString();
-            }
+            message = strVal.GetString();
         }
 
         // Get timestamp
         var timestamp = DateTimeOffset.UtcNow;
-        if (logRecord.TryGetProperty("timeUnixNano", out var timeNano))
+        if (logRecord.TryGetProperty("timeUnixNano", out var timeNano) &&
+            timeNano.TryGetUInt64(out var nanos))
         {
-            if (timeNano.TryGetUInt64(out var nanos))
-            {
-                timestamp = DateTimeOffset.FromUnixTimeMilliseconds((long)(nanos / 1_000_000));
-            }
+            timestamp = DateTimeOffset.FromUnixTimeMilliseconds((long)(nanos / 1_000_000));
         }
 
         // Get trace/span IDs
@@ -877,7 +870,7 @@ public sealed partial class OtlpParser(ILogger<OtlpParser> logger)
 
             return Math.Max(1, spanCount);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             LogJsonSpanParseFallback(ex);
             return Math.Max(1, bytes.Length / 300);
@@ -916,7 +909,7 @@ public sealed partial class OtlpParser(ILogger<OtlpParser> logger)
 
             return Math.Max(1, metricCount);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             LogJsonMetricParseFallback(ex);
             return Math.Max(1, bytes.Length / 100);
@@ -955,7 +948,7 @@ public sealed partial class OtlpParser(ILogger<OtlpParser> logger)
 
             return Math.Max(1, logCount);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             LogJsonLogParseFallback(ex);
             return Math.Max(1, bytes.Length / 150);
@@ -990,7 +983,7 @@ public sealed partial class OtlpParser(ILogger<OtlpParser> logger)
                     return [.. names];
                 }
             }
-            catch
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 // Not a trace request, try logs
             }
@@ -1007,7 +1000,7 @@ public sealed partial class OtlpParser(ILogger<OtlpParser> logger)
                     }
                 }
             }
-            catch
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 // Not a logs request either, return empty
             }
@@ -1025,7 +1018,7 @@ public sealed partial class OtlpParser(ILogger<OtlpParser> logger)
             ExtractServiceNamesFromResourceArray(root, "resourceMetrics", names);
             ExtractServiceNamesFromResourceArray(root, "resourceLogs", names);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             LogServiceNameExtractionFailed(ex);
         }
@@ -1084,7 +1077,7 @@ public sealed partial class OtlpParser(ILogger<OtlpParser> logger)
                 }
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             LogErrorSpanExtractionFailed(ex);
         }
@@ -1120,7 +1113,7 @@ public sealed partial class OtlpParser(ILogger<OtlpParser> logger)
                 }
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             LogProtobufTraceParseError(ex);
         }
@@ -1179,7 +1172,7 @@ public sealed partial class OtlpParser(ILogger<OtlpParser> logger)
                 }
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             LogErrorLogExtractionFailed(ex);
         }
@@ -1239,7 +1232,7 @@ public sealed partial class OtlpParser(ILogger<OtlpParser> logger)
                 }
             }
         }
-        catch
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             // Ignore parsing errors for severity extraction
         }
@@ -1273,7 +1266,7 @@ public sealed partial class OtlpParser(ILogger<OtlpParser> logger)
                 }
             }
         }
-        catch
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             // Ignore parsing errors for severity extraction
         }
@@ -1309,7 +1302,7 @@ public sealed partial class OtlpParser(ILogger<OtlpParser> logger)
                 }
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             LogProtobufLogParseError(ex);
         }

--- a/HoneyDrunk.Pulse/Pulse.Collector/Services/OtlpLogsService.cs
+++ b/HoneyDrunk.Pulse/Pulse.Collector/Services/OtlpLogsService.cs
@@ -70,7 +70,7 @@ public sealed class OtlpLogsService(
             // server error rates aren't inflated by ordinary disconnects.
             throw new RpcException(new Status(StatusCode.Cancelled, "Logs export cancelled by client"));
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogError(ex, "Error processing gRPC OTLP logs");
             throw new RpcException(new Status(StatusCode.Internal, "Error processing logs"));

--- a/HoneyDrunk.Pulse/Pulse.Collector/Services/OtlpMetricsService.cs
+++ b/HoneyDrunk.Pulse/Pulse.Collector/Services/OtlpMetricsService.cs
@@ -71,7 +71,7 @@ public sealed class OtlpMetricsService(
             // server error rates aren't inflated by ordinary disconnects.
             throw new RpcException(new Status(StatusCode.Cancelled, "Metrics export cancelled by client"));
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogError(ex, "Error processing gRPC OTLP metrics");
             throw new RpcException(new Status(StatusCode.Internal, "Error processing metrics"));

--- a/HoneyDrunk.Pulse/Pulse.Collector/Services/OtlpTraceService.cs
+++ b/HoneyDrunk.Pulse/Pulse.Collector/Services/OtlpTraceService.cs
@@ -69,7 +69,7 @@ public sealed class OtlpTraceService(
             // server error rates aren't inflated by ordinary disconnects.
             throw new RpcException(new Status(StatusCode.Cancelled, "Trace export cancelled by client"));
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             logger.LogError(ex, "Error processing gRPC OTLP traces");
             throw new RpcException(new Status(StatusCode.Internal, "Error processing traces"));


### PR DESCRIPTION
## Summary
Addresses 39 of the 57 real-source CodeQL findings open on Pulse.

**Catches narrowed (36 sites):**
- Every `catch (Exception ex)` and parameterless `catch` flagged by CodeQL is now `catch (Exception ex) when (ex is not OperationCanceledException)`.
- Touches: OtlpParser, IngestionPipeline, OtlpEndpoints, OtlpLogs/Metrics/TraceService, sample Worker, PulseAnalyticsEmitter, AzureMonitorSink, PostHogSink.
- Effect: cancellation propagates correctly. The defensive "parse/dispatch and degrade" fallbacks no longer silently swallow `OperationCanceledException` (which can be raised in async parse methods, gRPC service handlers, and dispatch loops).
- (`cs/catch-of-all-exceptions`)

**Nested ifs flattened (3 sites in OtlpParser):**
- Service-name extraction (line 446 area), log message body, and log timestamp now combine their `TryGetProperty` checks with `&&` instead of nesting. (`cs/nested-if-statements`)

## What's not in this PR
The remaining 17 findings are pure style notes:
- `cs/linq/missed-where` × 14
- `cs/linq/missed-select` × 3

All sit on `foreach (var x in jsonElement.EnumerateArray()) { if (x.TryGetProperty("k", out var v) && ...) ... }` patterns. Converting to LINQ pulls `out var` into a lambda and reduces readability for these JSON traversals. Dismissing separately as won't-fix.

## Test plan
- [x] `dotnet build` — 0 errors
- [ ] PR CodeQL run shows the 36 catch alerts and 3 nested-if alerts cleared
- [ ] No new alerts introduced
- [ ] Existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)