### PR TITLE
feat: add ADR-0026 tenant telemetry tag

### DIFF
--- a/HoneyDrunk.Pulse/CHANGELOG.md
+++ b/HoneyDrunk.Pulse/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added ADR-0026 tenant context propagation for Pulse collector ingress, analytics events, error reports, and low-cardinality collector telemetry tags.
 - Added a PostHog credential rotation canary covering per-flush Vault secret resolution.
 
 ## [0.1.0] - 2026-02-21

--- a/HoneyDrunk.Pulse/CHANGELOG.md
+++ b/HoneyDrunk.Pulse/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [HoneyDrunk.Telemetry.Sink.Sentry](HoneyDrunk.Telemetry.Sink.Sentry/CHANGELOG.md)
 - [HoneyDrunk.Telemetry.Sink.AzureMonitor](HoneyDrunk.Telemetry.Sink.AzureMonitor/CHANGELOG.md)
 
-## [Unreleased]
+## [0.2.0] - 2026-05-04
 
 ### Changed
 

--- a/HoneyDrunk.Pulse/HoneyDrunk.Pulse.Contracts/CHANGELOG.md
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Pulse.Contracts/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to HoneyDrunk.Pulse.Contracts will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-05-04
+
+### Changed
+
+- Released 0.2.0 as part of the ADR-0026 tenancy rollout and solution-wide package version alignment.
+
 ## [0.1.0] - 2026-02-21
 
 ### Added

--- a/HoneyDrunk.Pulse/HoneyDrunk.Pulse.Contracts/HoneyDrunk.Pulse.Contracts.csproj
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Pulse.Contracts/HoneyDrunk.Pulse.Contracts.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
@@ -9,7 +9,7 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Pulse.Contracts</PackageId>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Shared event contracts and DTOs for HoneyDrunk.Pulse telemetry pipeline. Multi-target (netstandard2.0, net8.0, net10.0) for broad consumer compatibility.</Description>
     <PackageReleaseNotes>v0.1.0: Initial release. See CHANGELOG.md for details.</PackageReleaseNotes>

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Abstractions/CHANGELOG.md
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Abstractions/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to HoneyDrunk.Telemetry.Abstractions will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Documented ADR-0026 `honeydrunk.tenant_id` as a bounded, low-cardinality telemetry tag.
+
 ## [0.1.0] - 2026-02-21
 
 ### Added

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Abstractions/CHANGELOG.md
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Abstractions/CHANGELOG.md
@@ -5,11 +5,19 @@ All notable changes to HoneyDrunk.Telemetry.Abstractions will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.0] - 2026-05-04
 
 ### Added
 
-- Documented ADR-0026 `honeydrunk.tenant_id` as a bounded, low-cardinality telemetry tag.
+- Documented ADR-0026 `tenant_id` as a bounded, low-cardinality telemetry tag.
+
+### Changed
+
+- Bumped package version to 0.2.0 for the coordinated ADR-0026 tenancy rollout.
+
+### Added
+
+- Documented ADR-0026 `tenant_id` as a bounded, low-cardinality telemetry tag.
 
 ## [0.1.0] - 2026-02-21
 

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Abstractions/HoneyDrunk.Telemetry.Abstractions.csproj
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Abstractions/HoneyDrunk.Telemetry.Abstractions.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -8,7 +8,7 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Telemetry.Abstractions</PackageId>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Pure abstractions for HoneyDrunk telemetry sinks and instrumentation. Defines ITraceSink, ILogSink, IMetricsSink, IAnalyticsSink, IErrorSink, and telemetry event models.</Description>
     <PackageReleaseNotes>v0.1.0: Initial release. See CHANGELOG.md for details.</PackageReleaseNotes>

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Abstractions/Tags/TelemetryTagKeys.cs
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Abstractions/Tags/TelemetryTagKeys.cs
@@ -52,6 +52,11 @@ public static class TelemetryTagKeys
         /// <summary>
         /// The tenant ID for multi-tenant scenarios.
         /// </summary>
+        /// <remarks>
+        /// ADR-0026 treats this as a low-cardinality telemetry dimension: v1 paying customers are
+        /// expected in the tens, and continued use as a metric tag is bounded by Notify Cloud's
+        /// cardinality kill criteria. Do not substitute user, session, node, or request identifiers here.
+        /// </remarks>
         public const string TenantId = $"{Prefix}.tenant_id";
 
         /// <summary>

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Abstractions/Tags/TelemetryTagKeys.cs
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Abstractions/Tags/TelemetryTagKeys.cs
@@ -57,7 +57,7 @@ public static class TelemetryTagKeys
         /// expected in the tens, and continued use as a metric tag is bounded by Notify Cloud's
         /// cardinality kill criteria. Do not substitute user, session, node, or request identifiers here.
         /// </remarks>
-        public const string TenantId = $"{Prefix}.tenant_id";
+        public const string TenantId = "tenant_id";
 
         /// <summary>
         /// The user ID associated with the operation.

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.OpenTelemetry/CHANGELOG.md
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.OpenTelemetry/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to HoneyDrunk.Telemetry.OpenTelemetry will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-05-04
+
+### Added
+
+- Serialized analytics event tenant context when emitting events to Pulse.Collector.
+
+### Changed
+
+- Bumped package version to 0.2.0 for the coordinated ADR-0026 tenancy rollout.
+
 ## [0.1.0] - 2026-02-21
 
 ### Added

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.OpenTelemetry/HoneyDrunk.Telemetry.OpenTelemetry.csproj
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.OpenTelemetry/HoneyDrunk.Telemetry.OpenTelemetry.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -19,7 +19,7 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Telemetry.OpenTelemetry</PackageId>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>OpenTelemetry integration for HoneyDrunk Grid Nodes. Provides preconfigured tracing, metrics, and logging pipelines with OTLP export and Grid context enrichment.</Description>
     <PackageReleaseNotes>v0.1.0: Initial release. See CHANGELOG.md for details.</PackageReleaseNotes>

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.OpenTelemetry/PulseAnalyticsEmitter.cs
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.OpenTelemetry/PulseAnalyticsEmitter.cs
@@ -59,6 +59,7 @@ public sealed partial class PulseAnalyticsEmitter(
                     SessionId = e.SessionId,
                     CorrelationId = e.CorrelationId,
                     NodeId = e.NodeId,
+                    TenantId = e.TenantId,
                     Environment = e.Environment,
                     Properties = e.Properties,
                 })],
@@ -131,6 +132,8 @@ public sealed partial class PulseAnalyticsEmitter(
         public string? CorrelationId { get; init; }
 
         public string? NodeId { get; init; }
+
+        public string? TenantId { get; init; }
 
         public string? Environment { get; init; }
 

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.AzureMonitor/CHANGELOG.md
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.AzureMonitor/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to HoneyDrunk.Telemetry.Sink.AzureMonitor will be documented
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-05-04
+
+### Changed
+
+- Released 0.2.0 as part of the ADR-0026 tenancy rollout and solution-wide package version alignment.
+
 ## [0.1.0] - 2026-02-21
 
 ### Added

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.AzureMonitor/HoneyDrunk.Telemetry.Sink.AzureMonitor.csproj
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.AzureMonitor/HoneyDrunk.Telemetry.Sink.AzureMonitor.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -8,7 +8,7 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Telemetry.Sink.AzureMonitor</PackageId>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Azure Monitor sink for HoneyDrunk telemetry. Exports traces, metrics, and logs to Application Insights using the Azure Monitor OpenTelemetry exporter.</Description>
     <PackageReleaseNotes>v0.1.0: Initial release. See CHANGELOG.md for details.</PackageReleaseNotes>

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Loki/CHANGELOG.md
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Loki/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to HoneyDrunk.Telemetry.Sink.Loki will be documented in this
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.0] - 2026-05-04
+
+### Changed
+
+- Released 0.2.0 as part of the ADR-0026 tenancy rollout and solution-wide package version alignment.
 
 ### Changed
 

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Loki/HoneyDrunk.Telemetry.Sink.Loki.csproj
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Loki/HoneyDrunk.Telemetry.Sink.Loki.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -8,7 +8,7 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Telemetry.Sink.Loki</PackageId>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Grafana Loki log sink for HoneyDrunk telemetry. Forwards OTLP log data to Loki with configurable log level filtering and multi-tenant support.</Description>
     <PackageReleaseNotes>v0.1.0: Initial release. See CHANGELOG.md for details.</PackageReleaseNotes>

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Mimir/CHANGELOG.md
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Mimir/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to HoneyDrunk.Telemetry.Sink.Mimir will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.0] - 2026-05-04
+
+### Changed
+
+- Released 0.2.0 as part of the ADR-0026 tenancy rollout and solution-wide package version alignment.
 
 ### Changed
 

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Mimir/HoneyDrunk.Telemetry.Sink.Mimir.csproj
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Mimir/HoneyDrunk.Telemetry.Sink.Mimir.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -8,7 +8,7 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Telemetry.Sink.Mimir</PackageId>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Grafana Mimir metrics sink for HoneyDrunk telemetry. Forwards OTLP metrics data to Mimir for long-term metrics storage and querying.</Description>
     <PackageReleaseNotes>v0.1.0: Initial release. See CHANGELOG.md for details.</PackageReleaseNotes>

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.PostHog/CHANGELOG.md
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.PostHog/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to HoneyDrunk.Telemetry.Sink.PostHog will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.0] - 2026-05-04
+
+### Changed
+
+- Replaced configured PostHog API key values with `ApiKeySecretName`, defaulting to `PostHog--ApiKey`.
+- Resolve the PostHog API key from `ISecretStore` for each flush so rotation propagates without restart.
+- Bumped package version to 0.2.0 for the coordinated ADR-0026 tenancy rollout.
 
 ### Changed
 

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.PostHog/HoneyDrunk.Telemetry.Sink.PostHog.csproj
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.PostHog/HoneyDrunk.Telemetry.Sink.PostHog.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -8,7 +8,7 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Telemetry.Sink.PostHog</PackageId>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>PostHog analytics sink for HoneyDrunk telemetry. Captures product analytics events with batching, retry logic, and rate-limit handling.</Description>
     <PackageReleaseNotes>v0.1.0: Initial release. See CHANGELOG.md for details.</PackageReleaseNotes>

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Sentry/CHANGELOG.md
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Sentry/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to HoneyDrunk.Telemetry.Sink.Sentry will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.0] - 2026-05-04
+
+### Changed
+
+- Released 0.2.0 as part of the ADR-0026 tenancy rollout and solution-wide package version alignment.
 
 ### Changed
 

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Sentry/HoneyDrunk.Telemetry.Sink.Sentry.csproj
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Sentry/HoneyDrunk.Telemetry.Sink.Sentry.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -8,7 +8,7 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Telemetry.Sink.Sentry</PackageId>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Sentry error tracking sink for HoneyDrunk telemetry. Routes error events, exceptions, and error spans to Sentry with enriched Grid context.</Description>
     <PackageReleaseNotes>v0.1.0: Initial release. See CHANGELOG.md for details.</PackageReleaseNotes>

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Tempo/CHANGELOG.md
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Tempo/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to HoneyDrunk.Telemetry.Sink.Tempo will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.0] - 2026-05-04
+
+### Changed
+
+- Released 0.2.0 as part of the ADR-0026 tenancy rollout and solution-wide package version alignment.
 
 ### Changed
 

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Tempo/HoneyDrunk.Telemetry.Sink.Tempo.csproj
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Tempo/HoneyDrunk.Telemetry.Sink.Tempo.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -8,7 +8,7 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Telemetry.Sink.Tempo</PackageId>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Grafana Tempo trace sink for HoneyDrunk telemetry. Forwards OTLP trace data to Tempo for distributed trace storage and querying.</Description>
     <PackageReleaseNotes>v0.1.0: Initial release. See CHANGELOG.md for details.</PackageReleaseNotes>

--- a/HoneyDrunk.Pulse/Pulse.Collector/Endpoints/AnalyticsEventItem.cs
+++ b/HoneyDrunk.Pulse/Pulse.Collector/Endpoints/AnalyticsEventItem.cs
@@ -45,6 +45,11 @@ public sealed class AnalyticsEventItem
     public string? NodeId { get; set; }
 
     /// <summary>
+    /// Gets or sets the tenant ID.
+    /// </summary>
+    public string? TenantId { get; set; }
+
+    /// <summary>
     /// Gets or sets the environment.
     /// </summary>
     public string? Environment { get; set; }

--- a/HoneyDrunk.Pulse/Pulse.Collector/Endpoints/ErrorReportRequest.cs
+++ b/HoneyDrunk.Pulse/Pulse.Collector/Endpoints/ErrorReportRequest.cs
@@ -47,6 +47,11 @@ public sealed class ErrorReportRequest
     public string? UserId { get; set; }
 
     /// <summary>
+    /// Gets or sets the tenant ID.
+    /// </summary>
+    public string? TenantId { get; set; }
+
+    /// <summary>
     /// Gets or sets the environment.
     /// </summary>
     public string? Environment { get; set; }

--- a/HoneyDrunk.Pulse/Pulse.Collector/Endpoints/OtlpEndpoints.cs
+++ b/HoneyDrunk.Pulse/Pulse.Collector/Endpoints/OtlpEndpoints.cs
@@ -4,6 +4,7 @@
 
 using HoneyDrunk.Pulse.Collector.Ingestion;
 using HoneyDrunk.Telemetry.Abstractions.Models;
+using HoneyDrunk.Telemetry.Abstractions.Tags;
 using System.Text.Json;
 
 namespace HoneyDrunk.Pulse.Collector.Endpoints;
@@ -53,6 +54,10 @@ public static class OtlpEndpoints
         return endpoints;
     }
 
+    private static string? ResolveTenantId(HttpContext context)
+        => context.Request.Headers["X-Tenant-Id"].FirstOrDefault()
+            ?? context.Request.Headers["X-TenantId"].FirstOrDefault();
+
     private static async Task<IResult> HandleTracesAsync(
         HttpContext context,
         IngestionPipeline pipeline,
@@ -77,6 +82,7 @@ public static class OtlpEndpoints
             var sourceName = context.Request.Headers["X-Source-Service"].FirstOrDefault()
                 ?? (result.ResourceNames.Count > 0 ? result.ResourceNames[0] : null);
             var sourceNodeId = context.Request.Headers["X-Source-NodeId"].FirstOrDefault();
+            var tenantId = ResolveTenantId(context);
 
             // Pass error spans for forwarding to Sentry and raw OTLP data for trace sinks
             await pipeline.ProcessTracesAsync(
@@ -86,6 +92,7 @@ public static class OtlpEndpoints
                 result.ErrorSpans,
                 rawOtlpData: rawOtlpData,
                 contentType: contentType,
+                tenantId: tenantId,
                 cancellationToken: context.RequestAborted).ConfigureAwait(false);
 
             return Results.Ok(new
@@ -125,6 +132,7 @@ public static class OtlpEndpoints
             var sourceName = context.Request.Headers["X-Source-Service"].FirstOrDefault()
                 ?? (result.ResourceNames.Count > 0 ? result.ResourceNames[0] : null);
             var sourceNodeId = context.Request.Headers["X-Source-NodeId"].FirstOrDefault();
+            var tenantId = ResolveTenantId(context);
 
             await pipeline.ProcessMetricsAsync(
                 result.MetricCount,
@@ -132,6 +140,7 @@ public static class OtlpEndpoints
                 sourceNodeId,
                 rawOtlpData: rawOtlpData,
                 contentType: contentType,
+                tenantId: tenantId,
                 cancellationToken: context.RequestAborted).ConfigureAwait(false);
 
             return Results.Ok(new { Status = "accepted", result.MetricCount, result.DataPointCount });
@@ -166,6 +175,7 @@ public static class OtlpEndpoints
             var sourceName = context.Request.Headers["X-Source-Service"].FirstOrDefault()
                 ?? (result.ResourceNames.Count > 0 ? result.ResourceNames[0] : null);
             var sourceNodeId = context.Request.Headers["X-Source-NodeId"].FirstOrDefault();
+            var tenantId = ResolveTenantId(context);
 
             // Pass error logs for forwarding to Sentry and raw OTLP data for log sinks
             await pipeline.ProcessLogsAsync(
@@ -176,6 +186,7 @@ public static class OtlpEndpoints
                 rawOtlpData: rawOtlpData,
                 contentType: contentType,
                 maxSeverityNumber: result.MaxSeverityNumber,
+                tenantId: tenantId,
                 cancellationToken: context.RequestAborted).ConfigureAwait(false);
 
             return Results.Ok(new
@@ -218,6 +229,7 @@ public static class OtlpEndpoints
                     SessionId = e.SessionId,
                     CorrelationId = e.CorrelationId,
                     NodeId = e.NodeId,
+                    TenantId = e.TenantId,
                     Environment = e.Environment,
                 };
 
@@ -236,12 +248,14 @@ public static class OtlpEndpoints
                 ?? context.Request.Headers["X-Source-Service"].FirstOrDefault();
             var sourceNodeId = request.SourceNodeId
                 ?? context.Request.Headers["X-Source-NodeId"].FirstOrDefault();
+            var tenantId = ResolveTenantId(context);
 
             await pipeline.ProcessAnalyticsEventsAsync(
                 events,
                 sourceName,
                 sourceNodeId,
-                context.RequestAborted).ConfigureAwait(false);
+                tenantId: tenantId,
+                cancellationToken: context.RequestAborted).ConfigureAwait(false);
 
             return Results.Ok(new { Status = "accepted", events.Count });
         }
@@ -300,6 +314,12 @@ public static class OtlpEndpoints
             }
 
             var sourceName = context.Request.Headers["X-Source-Service"].FirstOrDefault();
+            var tenantId = request.TenantId ?? ResolveTenantId(context);
+            if (!string.IsNullOrEmpty(tenantId))
+            {
+                errorEvent.Tags[TelemetryTagKeys.HoneyDrunk.TenantId] = tenantId;
+            }
+
             await pipeline.ProcessErrorAsync(errorEvent, sourceName, context.RequestAborted).ConfigureAwait(false);
 
             return Results.Ok(new { Status = "accepted" });

--- a/HoneyDrunk.Pulse/Pulse.Collector/Ingestion/IngestionPipeline.cs
+++ b/HoneyDrunk.Pulse/Pulse.Collector/Ingestion/IngestionPipeline.cs
@@ -8,6 +8,7 @@ using HoneyDrunk.Pulse.Collector.Telemetry;
 using HoneyDrunk.Pulse.Collector.Transport;
 using HoneyDrunk.Telemetry.Abstractions.Abstractions;
 using HoneyDrunk.Telemetry.Abstractions.Models;
+using HoneyDrunk.Telemetry.Abstractions.Tags;
 using HoneyDrunk.Telemetry.Sink.Loki.Options;
 using Microsoft.Extensions.Options;
 using System.Diagnostics;
@@ -74,6 +75,7 @@ public sealed partial class IngestionPipeline(
     /// <param name="errorSpans">Error spans extracted from traces for forwarding to Sentry.</param>
     /// <param name="rawOtlpData">Raw OTLP protobuf data for forwarding to trace sinks.</param>
     /// <param name="contentType">Content type of the raw data (e.g., application/x-protobuf).</param>
+    /// <param name="tenantId">The tenant identifier carried with the telemetry batch.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
     public async Task ProcessTracesAsync(
@@ -83,6 +85,7 @@ public sealed partial class IngestionPipeline(
         IReadOnlyList<ExtractedErrorSpan>? errorSpans = null,
         ReadOnlyMemory<byte>? rawOtlpData = null,
         string? contentType = null,
+        string? tenantId = null,
         CancellationToken cancellationToken = default)
     {
         using var activity = CollectorTelemetry.StartIngestionActivity("ProcessTraces");
@@ -91,12 +94,12 @@ public sealed partial class IngestionPipeline(
 
         try
         {
-            CollectorTelemetry.RecordTracesIngested(traceCount, sourceName);
+            CollectorTelemetry.RecordTracesIngested(traceCount, sourceName, tenantId);
 
             // Forward error spans to Sentry
             if (errorSpans != null && errorSpans.Count > 0 && errorSink != null)
             {
-                await ForwardErrorSpansToSentryAsync(errorSpans, cancellationToken).ConfigureAwait(false);
+                await ForwardErrorSpansToSentryAsync(errorSpans, tenantId, cancellationToken).ConfigureAwait(false);
             }
 
             // Forward raw OTLP data to all trace sinks (Tempo, AzureMonitor, etc.)
@@ -129,14 +132,14 @@ public sealed partial class IngestionPipeline(
         catch (Exception ex)
         {
             LogTraceProcessingError(ex, sourceName);
-            CollectorTelemetry.RecordError("trace_processing");
+            CollectorTelemetry.RecordError("trace_processing", tenantId);
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             throw;
         }
         finally
         {
             stopwatch.Stop();
-            CollectorTelemetry.RecordProcessingDuration(stopwatch.ElapsedMilliseconds, sourceName);
+            CollectorTelemetry.RecordProcessingDuration(stopwatch.ElapsedMilliseconds, sourceName, tenantId);
         }
     }
 
@@ -148,6 +151,7 @@ public sealed partial class IngestionPipeline(
     /// <param name="sourceNodeId">The source node ID.</param>
     /// <param name="rawOtlpData">Raw OTLP protobuf data for forwarding to metrics sinks.</param>
     /// <param name="contentType">Content type of the raw data (e.g., application/x-protobuf).</param>
+    /// <param name="tenantId">The tenant identifier carried with the telemetry batch.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
     public async Task ProcessMetricsAsync(
@@ -156,6 +160,7 @@ public sealed partial class IngestionPipeline(
         string? sourceNodeId,
         ReadOnlyMemory<byte>? rawOtlpData = null,
         string? contentType = null,
+        string? tenantId = null,
         CancellationToken cancellationToken = default)
     {
         using var activity = CollectorTelemetry.StartIngestionActivity("ProcessMetrics");
@@ -164,7 +169,7 @@ public sealed partial class IngestionPipeline(
 
         try
         {
-            CollectorTelemetry.RecordMetricsIngested(metricCount, sourceName);
+            CollectorTelemetry.RecordMetricsIngested(metricCount, sourceName, tenantId);
 
             // Forward raw OTLP data to all metrics sinks (Mimir, AzureMonitor, etc.)
             if (rawOtlpData.HasValue && _metricsSinks.Count > 0)
@@ -196,14 +201,14 @@ public sealed partial class IngestionPipeline(
         catch (Exception ex)
         {
             LogMetricProcessingError(ex, sourceName);
-            CollectorTelemetry.RecordError("metric_processing");
+            CollectorTelemetry.RecordError("metric_processing", tenantId);
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             throw;
         }
         finally
         {
             stopwatch.Stop();
-            CollectorTelemetry.RecordProcessingDuration(stopwatch.ElapsedMilliseconds, sourceName);
+            CollectorTelemetry.RecordProcessingDuration(stopwatch.ElapsedMilliseconds, sourceName, tenantId);
         }
     }
 
@@ -217,6 +222,7 @@ public sealed partial class IngestionPipeline(
     /// <param name="rawOtlpData">Raw OTLP protobuf data for forwarding to log sinks.</param>
     /// <param name="contentType">Content type of the raw data (e.g., application/x-protobuf).</param>
     /// <param name="maxSeverityNumber">The maximum severity number in the batch for log level filtering.</param>
+    /// <param name="tenantId">The tenant identifier carried with the telemetry batch.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
     public async Task ProcessLogsAsync(
@@ -227,6 +233,7 @@ public sealed partial class IngestionPipeline(
         ReadOnlyMemory<byte>? rawOtlpData = null,
         string? contentType = null,
         int maxSeverityNumber = 0,
+        string? tenantId = null,
         CancellationToken cancellationToken = default)
     {
         using var activity = CollectorTelemetry.StartIngestionActivity("ProcessLogs");
@@ -235,12 +242,12 @@ public sealed partial class IngestionPipeline(
 
         try
         {
-            CollectorTelemetry.RecordLogsIngested(logCount, sourceName);
+            CollectorTelemetry.RecordLogsIngested(logCount, sourceName, tenantId);
 
             // Forward error logs to Sentry
             if (errorLogs != null && errorLogs.Count > 0 && errorSink != null)
             {
-                await ForwardErrorLogsToSentryAsync(errorLogs, sourceName, cancellationToken).ConfigureAwait(false);
+                await ForwardErrorLogsToSentryAsync(errorLogs, sourceName, tenantId, cancellationToken).ConfigureAwait(false);
             }
 
             // Forward raw OTLP data to all log sinks (Loki, AzureMonitor, etc.)
@@ -274,14 +281,14 @@ public sealed partial class IngestionPipeline(
         catch (Exception ex)
         {
             LogLogProcessingError(ex, sourceName);
-            CollectorTelemetry.RecordError("log_processing");
+            CollectorTelemetry.RecordError("log_processing", tenantId);
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             throw;
         }
         finally
         {
             stopwatch.Stop();
-            CollectorTelemetry.RecordProcessingDuration(stopwatch.ElapsedMilliseconds, sourceName);
+            CollectorTelemetry.RecordProcessingDuration(stopwatch.ElapsedMilliseconds, sourceName, tenantId);
         }
     }
 
@@ -291,12 +298,14 @@ public sealed partial class IngestionPipeline(
     /// <param name="events">The analytics events.</param>
     /// <param name="sourceName">The source service name.</param>
     /// <param name="sourceNodeId">The source node ID.</param>
+    /// <param name="tenantId">The tenant identifier carried with the telemetry batch.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
     public async Task ProcessAnalyticsEventsAsync(
         IEnumerable<TelemetryEvent> events,
         string? sourceName,
         string? sourceNodeId,
+        string? tenantId = null,
         CancellationToken cancellationToken = default)
     {
         using var activity = CollectorTelemetry.StartIngestionActivity("ProcessAnalyticsEvents");
@@ -306,9 +315,15 @@ public sealed partial class IngestionPipeline(
 
         try
         {
-            // Enrich analytics events with HoneyDrunk context
+            // Enrich analytics events with HoneyDrunk context.
+            // Header-level tenancy is copied onto events so downstream analytics sinks receive tenant_id.
             foreach (var evt in eventList)
             {
+                if (string.IsNullOrEmpty(evt.TenantId))
+                {
+                    evt.TenantId = tenantId;
+                }
+
                 enricher.EnrichTelemetryEvent(evt, sourceName);
             }
 
@@ -325,7 +340,8 @@ public sealed partial class IngestionPipeline(
                 }
             }
 
-            CollectorTelemetry.RecordAnalyticsEventsIngested(eventList.Count, sourceName);
+            tenantId ??= eventList.FirstOrDefault(evt => !string.IsNullOrEmpty(evt.TenantId))?.TenantId;
+            CollectorTelemetry.RecordAnalyticsEventsIngested(eventList.Count, sourceName, tenantId);
 
             LogAnalyticsEventsProcessed(eventList.Count, sourceName ?? "unknown");
 
@@ -348,14 +364,14 @@ public sealed partial class IngestionPipeline(
         catch (Exception ex)
         {
             LogAnalyticsProcessingError(ex, sourceName);
-            CollectorTelemetry.RecordError("analytics_processing");
+            CollectorTelemetry.RecordError("analytics_processing", tenantId);
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             throw;
         }
         finally
         {
             stopwatch.Stop();
-            CollectorTelemetry.RecordProcessingDuration(stopwatch.ElapsedMilliseconds, sourceName);
+            CollectorTelemetry.RecordProcessingDuration(stopwatch.ElapsedMilliseconds, sourceName, tenantId);
         }
     }
 
@@ -580,6 +596,7 @@ public sealed partial class IngestionPipeline(
     /// </summary>
     private async Task ForwardErrorSpansToSentryAsync(
         IReadOnlyList<ExtractedErrorSpan> errorSpans,
+        string? tenantId,
         CancellationToken cancellationToken)
     {
         foreach (var errorSpan in errorSpans)
@@ -600,6 +617,11 @@ public sealed partial class IngestionPipeline(
 
                 // Add tags
                 errorEvent.Tags["span.name"] = errorSpan.SpanName;
+
+                if (!string.IsNullOrEmpty(tenantId))
+                {
+                    errorEvent.Tags[TelemetryTagKeys.HoneyDrunk.TenantId] = tenantId;
+                }
 
                 if (!string.IsNullOrEmpty(errorSpan.TraceId))
                 {
@@ -640,7 +662,7 @@ public sealed partial class IngestionPipeline(
 
                 await errorSink!.CaptureAsync(errorEvent, cancellationToken).ConfigureAwait(false);
 
-                CollectorTelemetry.RecordErrorForwarded(errorSpan.ServiceName);
+                CollectorTelemetry.RecordErrorForwarded(errorSpan.ServiceName, tenantId);
 
                 LogErrorSpanForwarded(errorSpan.SpanName, errorSpan.ServiceName ?? "unknown");
             }
@@ -657,6 +679,7 @@ public sealed partial class IngestionPipeline(
     private async Task ForwardErrorLogsToSentryAsync(
         IReadOnlyList<ExtractedErrorLog> errorLogs,
         string? sourceName,
+        string? tenantId,
         CancellationToken cancellationToken)
     {
         foreach (var errorLog in errorLogs)
@@ -672,6 +695,11 @@ public sealed partial class IngestionPipeline(
                 };
 
                 // Add log attributes as tags
+                if (!string.IsNullOrEmpty(tenantId))
+                {
+                    errorEvent.Tags[TelemetryTagKeys.HoneyDrunk.TenantId] = tenantId;
+                }
+
                 if (!string.IsNullOrEmpty(errorLog.TraceId))
                 {
                     errorEvent.Tags["trace.id"] = errorLog.TraceId;
@@ -720,7 +748,7 @@ public sealed partial class IngestionPipeline(
 
                 await errorSink!.CaptureAsync(errorEvent, cancellationToken).ConfigureAwait(false);
 
-                CollectorTelemetry.RecordErrorForwarded(sourceName ?? errorLog.ServiceName);
+                CollectorTelemetry.RecordErrorForwarded(sourceName ?? errorLog.ServiceName, tenantId);
 
                 LogErrorLogForwarded(errorLog.SeverityText ?? "ERROR", sourceName ?? errorLog.ServiceName ?? "unknown");
             }

--- a/HoneyDrunk.Pulse/Pulse.Collector/Ingestion/IngestionPipeline.cs
+++ b/HoneyDrunk.Pulse/Pulse.Collector/Ingestion/IngestionPipeline.cs
@@ -340,7 +340,7 @@ public sealed partial class IngestionPipeline(
                 }
             }
 
-            tenantId ??= eventList.FirstOrDefault(evt => !string.IsNullOrEmpty(evt.TenantId))?.TenantId;
+            tenantId ??= ResolveBatchTenantForMetrics(eventList);
             CollectorTelemetry.RecordAnalyticsEventsIngested(eventList.Count, sourceName, tenantId);
 
             LogAnalyticsEventsProcessed(eventList.Count, sourceName ?? "unknown");
@@ -428,6 +428,18 @@ public sealed partial class IngestionPipeline(
     /// Exports trace data to all registered trace sinks.
     /// </summary>
     /// <returns>The number of sinks that failed.</returns>
+    private static string? ResolveBatchTenantForMetrics(IReadOnlyCollection<TelemetryEvent> events)
+    {
+        var distinctTenantIds = events
+            .Select(evt => evt.TenantId)
+            .Where(tenant => !string.IsNullOrEmpty(tenant))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Take(2)
+            .ToList();
+
+        return distinctTenantIds.Count == 1 ? distinctTenantIds[0] : null;
+    }
+
     private async Task<int> ExportToTraceSinksAsync(
         ReadOnlyMemory<byte> data,
         string contentType,

--- a/HoneyDrunk.Pulse/Pulse.Collector/Services/OtlpLogsService.cs
+++ b/HoneyDrunk.Pulse/Pulse.Collector/Services/OtlpLogsService.cs
@@ -41,6 +41,8 @@ public sealed class OtlpLogsService(
             var sourceName = context.RequestHeaders.GetValue("x-source-service")
                 ?? (result.ResourceNames.Count > 0 ? result.ResourceNames[0] : null);
             var sourceNodeId = context.RequestHeaders.GetValue("x-source-nodeid");
+            var tenantId = context.RequestHeaders.GetValue("x-tenant-id")
+                ?? context.RequestHeaders.GetValue("x-tenantid");
 
             // Process through the pipeline with error logs and raw bytes for sink forwarding
             await pipeline.ProcessLogsAsync(
@@ -51,6 +53,7 @@ public sealed class OtlpLogsService(
                 rawOtlpData: rawOtlpData,
                 contentType: "application/x-protobuf",
                 maxSeverityNumber: result.MaxSeverityNumber,
+                tenantId: tenantId,
                 cancellationToken: context.CancellationToken).ConfigureAwait(false);
 
             if (logger.IsEnabled(LogLevel.Debug))

--- a/HoneyDrunk.Pulse/Pulse.Collector/Services/OtlpMetricsService.cs
+++ b/HoneyDrunk.Pulse/Pulse.Collector/Services/OtlpMetricsService.cs
@@ -45,6 +45,8 @@ public sealed class OtlpMetricsService(
             var sourceName = context.RequestHeaders.GetValue("x-source-service")
                 ?? (result.ResourceNames.Count > 0 ? result.ResourceNames[0] : null);
             var sourceNodeId = context.RequestHeaders.GetValue("x-source-nodeid");
+            var tenantId = context.RequestHeaders.GetValue("x-tenant-id")
+                ?? context.RequestHeaders.GetValue("x-tenantid");
 
             // Process through the pipeline with raw bytes for sink forwarding
             await pipeline.ProcessMetricsAsync(
@@ -53,6 +55,7 @@ public sealed class OtlpMetricsService(
                 sourceNodeId,
                 rawOtlpData: rawOtlpData,
                 contentType: "application/x-protobuf",
+                tenantId: tenantId,
                 cancellationToken: context.CancellationToken).ConfigureAwait(false);
 
             if (logger.IsEnabled(LogLevel.Debug))

--- a/HoneyDrunk.Pulse/Pulse.Collector/Services/OtlpTraceService.cs
+++ b/HoneyDrunk.Pulse/Pulse.Collector/Services/OtlpTraceService.cs
@@ -41,6 +41,8 @@ public sealed class OtlpTraceService(
             var sourceName = context.RequestHeaders.GetValue("x-source-service")
                 ?? (result.ResourceNames.Count > 0 ? result.ResourceNames[0] : null);
             var sourceNodeId = context.RequestHeaders.GetValue("x-source-nodeid");
+            var tenantId = context.RequestHeaders.GetValue("x-tenant-id")
+                ?? context.RequestHeaders.GetValue("x-tenantid");
 
             // Process through the pipeline with raw bytes for sink forwarding
             await pipeline.ProcessTracesAsync(
@@ -50,6 +52,7 @@ public sealed class OtlpTraceService(
                 result.ErrorSpans,
                 rawOtlpData: rawOtlpData,
                 contentType: "application/x-protobuf",
+                tenantId: tenantId,
                 cancellationToken: context.CancellationToken).ConfigureAwait(false);
 
             if (logger.IsEnabled(LogLevel.Debug))

--- a/HoneyDrunk.Pulse/Pulse.Collector/Telemetry/CollectorTelemetry.cs
+++ b/HoneyDrunk.Pulse/Pulse.Collector/Telemetry/CollectorTelemetry.cs
@@ -174,12 +174,22 @@ public sealed class CollectorTelemetry
             tags.Add(new KeyValuePair<string, object?>("source.name", sourceName));
         }
 
-        if (!string.IsNullOrEmpty(tenantId))
+        if (IsSafeTenantMetricTag(tenantId))
         {
             tags.Add(new KeyValuePair<string, object?>(TelemetryTagKeys.HoneyDrunk.TenantId, tenantId));
         }
 
         tags.AddRange(additionalTags);
         return [.. tags];
+    }
+
+    private static bool IsSafeTenantMetricTag(string? tenantId)
+    {
+        const string internalTenant = "00000000000000000000000000";
+        const string crockfordBase32 = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+        return tenantId is { Length: 26 }
+            && !string.Equals(tenantId, internalTenant, StringComparison.OrdinalIgnoreCase)
+            && tenantId.All(c => crockfordBase32.Contains(char.ToUpperInvariant(c)));
     }
 }

--- a/HoneyDrunk.Pulse/Pulse.Collector/Telemetry/CollectorTelemetry.cs
+++ b/HoneyDrunk.Pulse/Pulse.Collector/Telemetry/CollectorTelemetry.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using HoneyDrunk.Telemetry.Abstractions.Conventions;
+using HoneyDrunk.Telemetry.Abstractions.Tags;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 
@@ -75,9 +76,10 @@ public sealed class CollectorTelemetry
     /// </summary>
     /// <param name="count">The count.</param>
     /// <param name="sourceName">The source name.</param>
-    public static void RecordTracesIngested(long count, string? sourceName = null)
+    /// <param name="tenantId">The tenant identifier carried with the telemetry batch.</param>
+    public static void RecordTracesIngested(long count, string? sourceName = null, string? tenantId = null)
     {
-        var tags = CreateTags(sourceName);
+        var tags = CreateTags(sourceName, tenantId);
         TracesIngestedCounter.Add(count, tags);
     }
 
@@ -86,9 +88,10 @@ public sealed class CollectorTelemetry
     /// </summary>
     /// <param name="count">The count.</param>
     /// <param name="sourceName">The source name.</param>
-    public static void RecordMetricsIngested(long count, string? sourceName = null)
+    /// <param name="tenantId">The tenant identifier carried with the telemetry batch.</param>
+    public static void RecordMetricsIngested(long count, string? sourceName = null, string? tenantId = null)
     {
-        var tags = CreateTags(sourceName);
+        var tags = CreateTags(sourceName, tenantId);
         MetricsIngestedCounter.Add(count, tags);
     }
 
@@ -97,9 +100,10 @@ public sealed class CollectorTelemetry
     /// </summary>
     /// <param name="count">The count.</param>
     /// <param name="sourceName">The source name.</param>
-    public static void RecordLogsIngested(long count, string? sourceName = null)
+    /// <param name="tenantId">The tenant identifier carried with the telemetry batch.</param>
+    public static void RecordLogsIngested(long count, string? sourceName = null, string? tenantId = null)
     {
-        var tags = CreateTags(sourceName);
+        var tags = CreateTags(sourceName, tenantId);
         LogsIngestedCounter.Add(count, tags);
     }
 
@@ -108,9 +112,10 @@ public sealed class CollectorTelemetry
     /// </summary>
     /// <param name="count">The count.</param>
     /// <param name="sourceName">The source name.</param>
-    public static void RecordAnalyticsEventsIngested(long count, string? sourceName = null)
+    /// <param name="tenantId">The tenant identifier carried with the telemetry batch.</param>
+    public static void RecordAnalyticsEventsIngested(long count, string? sourceName = null, string? tenantId = null)
     {
-        var tags = CreateTags(sourceName);
+        var tags = CreateTags(sourceName, tenantId);
         AnalyticsEventsIngestedCounter.Add(count, tags);
     }
 
@@ -118,18 +123,20 @@ public sealed class CollectorTelemetry
     /// Records an error during ingestion.
     /// </summary>
     /// <param name="errorType">The type of error.</param>
-    public static void RecordError(string errorType)
+    /// <param name="tenantId">The tenant identifier carried with the telemetry batch.</param>
+    public static void RecordError(string errorType, string? tenantId = null)
     {
-        ErrorsCounter.Add(1, new KeyValuePair<string, object?>("error.type", errorType));
+        ErrorsCounter.Add(1, CreateTags(sourceName: null, tenantId, new KeyValuePair<string, object?>("error.type", errorType)));
     }
 
     /// <summary>
     /// Records an error forwarded to Sentry from trace spans.
     /// </summary>
     /// <param name="sourceName">The source service name.</param>
-    public static void RecordErrorForwarded(string? sourceName = null)
+    /// <param name="tenantId">The tenant identifier carried with the telemetry batch.</param>
+    public static void RecordErrorForwarded(string? sourceName = null, string? tenantId = null)
     {
-        var tags = CreateTags(sourceName);
+        var tags = CreateTags(sourceName, tenantId);
         ErrorsForwardedCounter.Add(1, tags);
     }
 
@@ -138,9 +145,10 @@ public sealed class CollectorTelemetry
     /// </summary>
     /// <param name="durationMs">The duration in milliseconds.</param>
     /// <param name="sourceName">The source name.</param>
-    public static void RecordProcessingDuration(double durationMs, string? sourceName = null)
+    /// <param name="tenantId">The tenant identifier carried with the telemetry batch.</param>
+    public static void RecordProcessingDuration(double durationMs, string? sourceName = null, string? tenantId = null)
     {
-        var tags = CreateTags(sourceName);
+        var tags = CreateTags(sourceName, tenantId);
         ProcessingDurationHistogram.Record(durationMs, tags);
     }
 
@@ -154,13 +162,24 @@ public sealed class CollectorTelemetry
         return ActivitySource.StartActivity(operationName, ActivityKind.Server);
     }
 
-    private static KeyValuePair<string, object?>[] CreateTags(string? sourceName)
+    private static KeyValuePair<string, object?>[] CreateTags(
+        string? sourceName,
+        string? tenantId,
+        params KeyValuePair<string, object?>[] additionalTags)
     {
-        if (string.IsNullOrEmpty(sourceName))
+        var tags = new List<KeyValuePair<string, object?>>(additionalTags.Length + 2);
+
+        if (!string.IsNullOrEmpty(sourceName))
         {
-            return [];
+            tags.Add(new KeyValuePair<string, object?>("source.name", sourceName));
         }
 
-        return [new KeyValuePair<string, object?>("source.name", sourceName)];
+        if (!string.IsNullOrEmpty(tenantId))
+        {
+            tags.Add(new KeyValuePair<string, object?>(TelemetryTagKeys.HoneyDrunk.TenantId, tenantId));
+        }
+
+        tags.AddRange(additionalTags);
+        return [.. tags];
     }
 }

--- a/HoneyDrunk.Pulse/Pulse.Tests/Collector/IngestionPipelineTests.cs
+++ b/HoneyDrunk.Pulse/Pulse.Tests/Collector/IngestionPipelineTests.cs
@@ -180,6 +180,28 @@ public class IngestionPipelineTests
     }
 
     /// <summary>
+    /// Tests that header-level tenant context is copied to analytics events without tenant IDs.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test operation.</returns>
+    [Fact]
+    public async Task ProcessAnalyticsEventsAsync_AppliesTenantIdToEvents()
+    {
+        // Arrange
+        var pipeline = CreatePipeline();
+        var events = new List<TelemetryEvent>
+        {
+            TelemetryEvent.Create("feature.used").WithDistinctId("user-1"),
+        };
+
+        // Act
+        await pipeline.ProcessAnalyticsEventsAsync(events, "app-service", "node-4", tenantId: "tenant-acme");
+
+        // Assert
+        _analyticsSink.CapturedBatches.Should().HaveCount(1);
+        _analyticsSink.CapturedBatches[0][0].TenantId.Should().Be("tenant-acme");
+    }
+
+    /// <summary>
     /// Tests that ProcessAnalyticsEventsAsync skips when sink is disabled.
     /// </summary>
     /// <returns>A task representing the asynchronous test operation.</returns>

--- a/HoneyDrunk.Pulse/Pulse.Tests/Telemetry/PostHogMappingTests.cs
+++ b/HoneyDrunk.Pulse/Pulse.Tests/Telemetry/PostHogMappingTests.cs
@@ -127,6 +127,30 @@ public class PostHogMappingTests
     }
 
     /// <summary>
+    /// Verifies that tenant context is included in the mapped event.
+    /// </summary>
+    [Fact]
+    public void Map_ShouldIncludeTenantId()
+    {
+        // Arrange
+        var options = new PostHogSinkOptions();
+        var mapper = new PostHogEventMapper(options);
+        var telemetryEvent = new TelemetryEvent
+        {
+            EventName = "test.event",
+            DistinctId = "user-1",
+            TenantId = "tenant-acme",
+        };
+
+        // Act
+        var result = mapper.Map(telemetryEvent);
+
+        // Assert
+        result.Properties.Should().ContainKey(TelemetryTagKeys.HoneyDrunk.TenantId);
+        result.Properties[TelemetryTagKeys.HoneyDrunk.TenantId].Should().Be("tenant-acme");
+    }
+
+    /// <summary>
     /// Verifies that custom properties are included in the mapped event.
     /// </summary>
     [Fact]

--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ The `TelemetryEnricher` automatically stamps all telemetry with:
 - `hive.studio.id` — Studio/organization context
 - `hive.environment` — Deployment environment
 - `hive.correlation.id` — Distributed correlation
-- `honeydrunk.tenant_id` — ADR-0026 tenant context for bounded, low-cardinality reporting
+- `tenant_id` — ADR-0026 tenant context for bounded, low-cardinality reporting
 
-Tenant discipline: `tenant_id` is safe as a Pulse metric tag only while v1 paying tenants remain in the tens; continued use is bounded by Notify Cloud's cardinality kill criteria, and user/session/request identifiers must not be placed in this dimension.
+Tenant discipline: `tenant_id` is safe as a Pulse metric tag only while v1 paying tenants remain in the tens; internal traffic and malformed tenant values are not emitted as metric labels, continued use is bounded by Notify Cloud's cardinality kill criteria, and user/session/request identifiers must not be placed in this dimension.
 
 ### 📤 Transport Event Publishing
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ The `TelemetryEnricher` automatically stamps all telemetry with:
 - `hive.studio.id` — Studio/organization context
 - `hive.environment` — Deployment environment
 - `hive.correlation.id` — Distributed correlation
+- `honeydrunk.tenant_id` — ADR-0026 tenant context for bounded, low-cardinality reporting
+
+Tenant discipline: `tenant_id` is safe as a Pulse metric tag only while v1 paying tenants remain in the tens; continued use is bounded by Notify Cloud's cardinality kill criteria, and user/session/request identifiers must not be placed in this dimension.
 
 ### 📤 Transport Event Publishing
 


### PR DESCRIPTION
## Summary
- add standard `honeydrunk.tenant_id` telemetry tag key with ADR-0026 cardinality discipline
- propagate tenant id through HTTP/gRPC OTLP ingestion into collector metrics/errors/durations
- propagate tenant id into analytics/error request DTOs and PostHog mapping tests

## Scope
Closes #9
ADR: https://github.com/HoneyDrunkStudios/HoneyDrunk.Architecture/blob/main/adrs/ADR-0026-grid-multi-tenant-primitives.md

## Validation
- `dotnet test HoneyDrunk.Pulse.slnx --no-restore` — passed 146/146 (NU1900 private-feed vulnerability lookup warnings only)
