### PR TITLE
Align Pulse Kernel identity and sink helpers

### DIFF
--- a/HoneyDrunk.Pulse/CHANGELOG.md
+++ b/HoneyDrunk.Pulse/CHANGELOG.md
@@ -17,6 +17,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [HoneyDrunk.Telemetry.Sink.Sentry](HoneyDrunk.Telemetry.Sink.Sentry/CHANGELOG.md)
 - [HoneyDrunk.Telemetry.Sink.AzureMonitor](HoneyDrunk.Telemetry.Sink.AzureMonitor/CHANGELOG.md)
 
+## [0.3.0] - 2026-05-18
+
+### Changed
+
+- Updated Pulse.Collector to use Kernel's canonical `WellKnownNodes.Ops.Pulse` fallback (`honeydrunk-pulse`) while preserving `HONEYDRUNK_NODE_ID` override behavior.
+- Updated Pulse.Collector dependencies to `HoneyDrunk.Kernel` 0.7.0 and `HoneyDrunk.Transport` 0.6.0 packages for compatible Kernel context contracts.
+- Aligned `HoneyDrunk.Kernel.Abstractions` references to 0.7.0 and all package versions to 0.3.0 for the coordinated Kernel adoption release.
+- Consolidated duplicated Loki, Mimir, and Tempo HTTP OTLP export/header/auth/retry behavior behind a shared linked helper while preserving sink-specific logging and option defaults.
+
+### Added
+
+- Added collector smoke tests pinning the default runtime Node ID to the canonical Kernel well-known Pulse identity.
+- Added sink tests covering shared HTTP OTLP custom header, Basic auth, Authorization header, and retry behavior.
+
 ## [0.2.0] - 2026-05-04
 
 ### Changed

--- a/HoneyDrunk.Pulse/HoneyDrunk.Pulse.Contracts/CHANGELOG.md
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Pulse.Contracts/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to HoneyDrunk.Pulse.Contracts will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-05-18
+
+### Changed
+
+- Aligned package version to 0.3.0 for the coordinated Kernel adoption release.
+
 ## [0.2.0] - 2026-05-04
 
 ### Changed

--- a/HoneyDrunk.Pulse/HoneyDrunk.Pulse.Contracts/HoneyDrunk.Pulse.Contracts.csproj
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Pulse.Contracts/HoneyDrunk.Pulse.Contracts.csproj
@@ -9,10 +9,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Pulse.Contracts</PackageId>
-    <Version>0.2.0</Version>
+    <Version>0.3.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Shared event contracts and DTOs for HoneyDrunk.Pulse telemetry pipeline. Multi-target (netstandard2.0, net8.0, net10.0) for broad consumer compatibility.</Description>
-    <PackageReleaseNotes>v0.1.0: Initial release. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.3.0: Kernel adoption alignment and HTTP OTLP sink helper consolidation. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>pulse;contracts;events;telemetry;dto;observability</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Abstractions/CHANGELOG.md
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Abstractions/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to HoneyDrunk.Telemetry.Abstractions will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-05-18
+
+### Changed
+
+- Updated `HoneyDrunk.Kernel.Abstractions` dependency to 0.7.0 for canonical Grid identity/context contracts.
+
 ## [0.2.0] - 2026-05-04
 
 ### Added

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Abstractions/HoneyDrunk.Telemetry.Abstractions.csproj
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Abstractions/HoneyDrunk.Telemetry.Abstractions.csproj
@@ -8,10 +8,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Telemetry.Abstractions</PackageId>
-    <Version>0.2.0</Version>
+    <Version>0.3.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Pure abstractions for HoneyDrunk telemetry sinks and instrumentation. Defines ITraceSink, ILogSink, IMetricsSink, IAnalyticsSink, IErrorSink, and telemetry event models.</Description>
-    <PackageReleaseNotes>v0.1.0: Initial release. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.3.0: Kernel adoption alignment and HTTP OTLP sink helper consolidation. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>telemetry;abstractions;sinks;traces;logs;metrics;analytics;errors;observability</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.4.0" />
+    <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.7.0" />
     <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.OpenTelemetry/CHANGELOG.md
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.OpenTelemetry/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to HoneyDrunk.Telemetry.OpenTelemetry will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-05-18
+
+### Changed
+
+- Updated `HoneyDrunk.Kernel.Abstractions` dependency to 0.7.0 for canonical Grid identity/context contracts.
+
 ## [0.2.0] - 2026-05-04
 
 ### Added

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.OpenTelemetry/HoneyDrunk.Telemetry.OpenTelemetry.csproj
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.OpenTelemetry/HoneyDrunk.Telemetry.OpenTelemetry.csproj
@@ -19,10 +19,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Telemetry.OpenTelemetry</PackageId>
-    <Version>0.2.0</Version>
+    <Version>0.3.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>OpenTelemetry integration for HoneyDrunk Grid Nodes. Provides preconfigured tracing, metrics, and logging pipelines with OTLP export and Grid context enrichment.</Description>
-    <PackageReleaseNotes>v0.1.0: Initial release. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.3.0: Kernel adoption alignment and HTTP OTLP sink helper consolidation. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>telemetry;opentelemetry;otel;tracing;metrics;logging;observability;instrumentation</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.4.0" />
+    <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.7.0" />
     <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.AzureMonitor/CHANGELOG.md
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.AzureMonitor/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to HoneyDrunk.Telemetry.Sink.AzureMonitor will be documented
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-05-18
+
+### Changed
+
+- Aligned package version to 0.3.0 for the coordinated Kernel adoption release.
+
 ## [0.2.0] - 2026-05-04
 
 ### Changed

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.AzureMonitor/HoneyDrunk.Telemetry.Sink.AzureMonitor.csproj
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.AzureMonitor/HoneyDrunk.Telemetry.Sink.AzureMonitor.csproj
@@ -8,10 +8,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Telemetry.Sink.AzureMonitor</PackageId>
-    <Version>0.2.0</Version>
+    <Version>0.3.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Azure Monitor sink for HoneyDrunk telemetry. Exports traces, metrics, and logs to Application Insights using the Azure Monitor OpenTelemetry exporter.</Description>
-    <PackageReleaseNotes>v0.1.0: Initial release. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.3.0: Kernel adoption alignment and HTTP OTLP sink helper consolidation. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>telemetry;sink;azure-monitor;application-insights;azure;observability</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Loki/CHANGELOG.md
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Loki/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to HoneyDrunk.Telemetry.Sink.Loki will be documented in this
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-05-18
+
+### Changed
+
+- Consolidated HTTP OTLP export, custom header, Vault-backed authorization, and retry behavior through the shared Grafana-family sink helper while preserving Loki-specific defaults and logging.
+
 ## [0.2.0] - 2026-05-04
 
 ### Changed

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Loki/HoneyDrunk.Telemetry.Sink.Loki.csproj
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Loki/HoneyDrunk.Telemetry.Sink.Loki.csproj
@@ -8,10 +8,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Telemetry.Sink.Loki</PackageId>
-    <Version>0.2.0</Version>
+    <Version>0.3.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Grafana Loki log sink for HoneyDrunk telemetry. Forwards OTLP log data to Loki with configurable log level filtering and multi-tenant support.</Description>
-    <PackageReleaseNotes>v0.1.0: Initial release. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.3.0: Kernel adoption alignment and HTTP OTLP sink helper consolidation. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>telemetry;sink;loki;grafana;logs;logging;observability</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -44,6 +44,12 @@
 
   <ItemGroup>
     <ProjectReference Include="..\HoneyDrunk.Telemetry.Abstractions\HoneyDrunk.Telemetry.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\HoneyDrunk.Telemetry.Sink.Shared\HttpOtlpSinkExporter.cs" Link="Shared\HttpOtlpSinkExporter.cs" />
+    <Compile Include="..\HoneyDrunk.Telemetry.Sink.Shared\HttpOtlpSinkLogCallbacks.cs" Link="Shared\HttpOtlpSinkLogCallbacks.cs" />
+    <Compile Include="..\HoneyDrunk.Telemetry.Sink.Shared\IHttpOtlpSinkOptions.cs" Link="Shared\IHttpOtlpSinkOptions.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Loki/HoneyDrunk.Telemetry.Sink.Loki.csproj
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Loki/HoneyDrunk.Telemetry.Sink.Loki.csproj
@@ -49,6 +49,7 @@
   <ItemGroup>
     <Compile Include="..\HoneyDrunk.Telemetry.Sink.Shared\HttpOtlpSinkExporter.cs" Link="Shared\HttpOtlpSinkExporter.cs" />
     <Compile Include="..\HoneyDrunk.Telemetry.Sink.Shared\HttpOtlpSinkLogCallbacks.cs" Link="Shared\HttpOtlpSinkLogCallbacks.cs" />
+    <Compile Include="..\HoneyDrunk.Telemetry.Sink.Shared\HttpOtlpSinkOptionsAdapter.cs" Link="Shared\HttpOtlpSinkOptionsAdapter.cs" />
     <Compile Include="..\HoneyDrunk.Telemetry.Sink.Shared\IHttpOtlpSinkOptions.cs" Link="Shared\IHttpOtlpSinkOptions.cs" />
   </ItemGroup>
 

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Loki/Implementation/LokiSink.cs
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Loki/Implementation/LokiSink.cs
@@ -41,7 +41,15 @@ public sealed partial class LokiSink(
         await HttpOtlpSinkExporter.ExportAsync(
             httpClient,
             secretStore,
-            _options,
+            new HttpOtlpSinkOptionsAdapter(
+                _options.Endpoint,
+                _options.Enabled,
+                _options.TimeoutSeconds,
+                _options.MaxRetries,
+                _options.Headers,
+                _options.BasicAuthSecretName,
+                _options.UsernameSecretName,
+                _options.PasswordSecretName),
             logData,
             contentType,
             new HttpOtlpSinkLogCallbacks(

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Loki/Implementation/LokiSink.cs
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Loki/Implementation/LokiSink.cs
@@ -4,12 +4,10 @@
 
 using HoneyDrunk.Telemetry.Abstractions.Abstractions;
 using HoneyDrunk.Telemetry.Sink.Loki.Options;
+using HoneyDrunk.Telemetry.Sink.Shared;
 using HoneyDrunk.Vault.Abstractions;
-using HoneyDrunk.Vault.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using System.Net.Http.Headers;
-using System.Text;
 
 namespace HoneyDrunk.Telemetry.Sink.Loki.Implementation;
 
@@ -40,55 +38,18 @@ public sealed partial class LokiSink(
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
-        if (!_options.Enabled)
-        {
-            return;
-        }
-
-        if (string.IsNullOrEmpty(_options.Endpoint))
-        {
-            LogEndpointNotConfigured();
-            return;
-        }
-
-        var attempt = 0;
-        while (attempt < _options.MaxRetries)
-        {
-            try
-            {
-                using var content = new ByteArrayContent(logData.ToArray());
-                content.Headers.ContentType = new MediaTypeHeaderValue(contentType);
-                using var request = new HttpRequestMessage(HttpMethod.Post, new Uri(_options.Endpoint!))
-                {
-                    Content = content,
-                };
-
-                await ApplyRequestHeadersAsync(request, cancellationToken).ConfigureAwait(false);
-
-                using var response = await httpClient.SendAsync(request, cancellationToken)
-                    .ConfigureAwait(false);
-
-                if (response.IsSuccessStatusCode)
-                {
-                    LogLogsExported(logData.Length);
-                    return;
-                }
-
-                var responseBody = await response.Content
-                    .ReadAsStringAsync(cancellationToken)
-                    .ConfigureAwait(false);
-
-                LogExportFailed((int)response.StatusCode, responseBody);
-                attempt++;
-            }
-            catch (HttpRequestException ex) when (attempt < _options.MaxRetries - 1)
-            {
-                LogExportRetry(attempt + 1, _options.MaxRetries, ex.Message);
-                attempt++;
-                await Task.Delay(TimeSpan.FromMilliseconds(100 * Math.Pow(2, attempt)), cancellationToken)
-                    .ConfigureAwait(false);
-            }
-        }
+        await HttpOtlpSinkExporter.ExportAsync(
+            httpClient,
+            secretStore,
+            _options,
+            logData,
+            contentType,
+            new HttpOtlpSinkLogCallbacks(
+                LogLogsExported,
+                LogExportFailed,
+                LogExportRetry,
+                LogEndpointNotConfigured),
+            cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -132,64 +93,4 @@ public sealed partial class LokiSink(
         Level = LogLevel.Warning,
         Message = "Loki endpoint not configured, skipping export")]
     private partial void LogEndpointNotConfigured();
-
-    private async Task ApplyRequestHeadersAsync(
-        HttpRequestMessage request,
-        CancellationToken cancellationToken)
-    {
-        foreach (var header in _options.Headers)
-        {
-            request.Headers.TryAddWithoutValidation(header.Key, header.Value);
-        }
-
-        var basicAuth = await TryGetSecretValueAsync(_options.BasicAuthSecretName, cancellationToken)
-            .ConfigureAwait(false);
-        if (!string.IsNullOrWhiteSpace(basicAuth))
-        {
-            request.Headers.Authorization = BuildBasicAuthHeader(basicAuth);
-            return;
-        }
-
-        var username = await TryGetSecretValueAsync(_options.UsernameSecretName, cancellationToken)
-            .ConfigureAwait(false);
-        var password = await TryGetSecretValueAsync(_options.PasswordSecretName, cancellationToken)
-            .ConfigureAwait(false);
-        if (!string.IsNullOrWhiteSpace(username) && !string.IsNullOrWhiteSpace(password))
-        {
-            request.Headers.Authorization = BuildBasicAuthHeader($"{username}:{password}");
-        }
-    }
-
-    private async Task<string?> TryGetSecretValueAsync(string secretName, CancellationToken cancellationToken)
-    {
-        if (string.IsNullOrWhiteSpace(secretName))
-        {
-            return null;
-        }
-
-        var result = await secretStore
-            .TryGetSecretAsync(new SecretIdentifier(secretName), cancellationToken)
-            .ConfigureAwait(false);
-
-        return result.IsSuccess ? result.Value?.Value : null;
-    }
-
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "StyleCop.CSharp.OrderingRules",
-        "SA1204:Static elements should appear before instance elements",
-        Justification = "Helper kept adjacent to its only caller TryGetSecretValueAsync for readability.")]
-    private static AuthenticationHeaderValue BuildBasicAuthHeader(string value)
-    {
-        if (AuthenticationHeaderValue.TryParse(value, out var parsed)
-            && !string.IsNullOrWhiteSpace(parsed.Scheme))
-        {
-            return parsed;
-        }
-
-        var parameter = value.Contains(':', StringComparison.Ordinal)
-            ? Convert.ToBase64String(Encoding.UTF8.GetBytes(value))
-            : value;
-
-        return new AuthenticationHeaderValue("Basic", parameter);
-    }
 }

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Loki/Options/LokiSinkOptions.cs
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Loki/Options/LokiSinkOptions.cs
@@ -2,6 +2,7 @@
 // Copyright (c) HoneyDrunk Studios. All rights reserved.
 // </copyright>
 
+using HoneyDrunk.Telemetry.Sink.Shared;
 using Microsoft.Extensions.Logging;
 
 namespace HoneyDrunk.Telemetry.Sink.Loki.Options;
@@ -9,7 +10,7 @@ namespace HoneyDrunk.Telemetry.Sink.Loki.Options;
 /// <summary>
 /// Configuration options for the Loki log sink.
 /// </summary>
-public sealed class LokiSinkOptions
+public sealed class LokiSinkOptions : IHttpOtlpSinkOptions
 {
     /// <summary>
     /// The configuration section name.

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Loki/Options/LokiSinkOptions.cs
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Loki/Options/LokiSinkOptions.cs
@@ -2,7 +2,6 @@
 // Copyright (c) HoneyDrunk Studios. All rights reserved.
 // </copyright>
 
-using HoneyDrunk.Telemetry.Sink.Shared;
 using Microsoft.Extensions.Logging;
 
 namespace HoneyDrunk.Telemetry.Sink.Loki.Options;
@@ -10,7 +9,7 @@ namespace HoneyDrunk.Telemetry.Sink.Loki.Options;
 /// <summary>
 /// Configuration options for the Loki log sink.
 /// </summary>
-public sealed class LokiSinkOptions : IHttpOtlpSinkOptions
+public sealed class LokiSinkOptions
 {
     /// <summary>
     /// The configuration section name.

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Mimir/CHANGELOG.md
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Mimir/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to HoneyDrunk.Telemetry.Sink.Mimir will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-05-18
+
+### Changed
+
+- Consolidated HTTP OTLP export, custom header, Vault-backed authorization, and retry behavior through the shared Grafana-family sink helper while preserving Mimir-specific defaults and logging.
+
 ## [0.2.0] - 2026-05-04
 
 ### Changed

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Mimir/HoneyDrunk.Telemetry.Sink.Mimir.csproj
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Mimir/HoneyDrunk.Telemetry.Sink.Mimir.csproj
@@ -8,10 +8,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Telemetry.Sink.Mimir</PackageId>
-    <Version>0.2.0</Version>
+    <Version>0.3.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Grafana Mimir metrics sink for HoneyDrunk telemetry. Forwards OTLP metrics data to Mimir for long-term metrics storage and querying.</Description>
-    <PackageReleaseNotes>v0.1.0: Initial release. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.3.0: Kernel adoption alignment and HTTP OTLP sink helper consolidation. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>telemetry;sink;mimir;grafana;metrics;observability</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -44,6 +44,12 @@
 
   <ItemGroup>
     <ProjectReference Include="..\HoneyDrunk.Telemetry.Abstractions\HoneyDrunk.Telemetry.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\HoneyDrunk.Telemetry.Sink.Shared\HttpOtlpSinkExporter.cs" Link="Shared\HttpOtlpSinkExporter.cs" />
+    <Compile Include="..\HoneyDrunk.Telemetry.Sink.Shared\HttpOtlpSinkLogCallbacks.cs" Link="Shared\HttpOtlpSinkLogCallbacks.cs" />
+    <Compile Include="..\HoneyDrunk.Telemetry.Sink.Shared\IHttpOtlpSinkOptions.cs" Link="Shared\IHttpOtlpSinkOptions.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Mimir/HoneyDrunk.Telemetry.Sink.Mimir.csproj
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Mimir/HoneyDrunk.Telemetry.Sink.Mimir.csproj
@@ -49,6 +49,7 @@
   <ItemGroup>
     <Compile Include="..\HoneyDrunk.Telemetry.Sink.Shared\HttpOtlpSinkExporter.cs" Link="Shared\HttpOtlpSinkExporter.cs" />
     <Compile Include="..\HoneyDrunk.Telemetry.Sink.Shared\HttpOtlpSinkLogCallbacks.cs" Link="Shared\HttpOtlpSinkLogCallbacks.cs" />
+    <Compile Include="..\HoneyDrunk.Telemetry.Sink.Shared\HttpOtlpSinkOptionsAdapter.cs" Link="Shared\HttpOtlpSinkOptionsAdapter.cs" />
     <Compile Include="..\HoneyDrunk.Telemetry.Sink.Shared\IHttpOtlpSinkOptions.cs" Link="Shared\IHttpOtlpSinkOptions.cs" />
   </ItemGroup>
 

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Mimir/Implementation/MimirSink.cs
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Mimir/Implementation/MimirSink.cs
@@ -41,7 +41,15 @@ public sealed partial class MimirSink(
         await HttpOtlpSinkExporter.ExportAsync(
             httpClient,
             secretStore,
-            _options,
+            new HttpOtlpSinkOptionsAdapter(
+                _options.Endpoint,
+                _options.Enabled,
+                _options.TimeoutSeconds,
+                _options.MaxRetries,
+                _options.Headers,
+                _options.BasicAuthSecretName,
+                _options.UsernameSecretName,
+                _options.PasswordSecretName),
             metricData,
             contentType,
             new HttpOtlpSinkLogCallbacks(

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Mimir/Implementation/MimirSink.cs
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Mimir/Implementation/MimirSink.cs
@@ -4,12 +4,10 @@
 
 using HoneyDrunk.Telemetry.Abstractions.Abstractions;
 using HoneyDrunk.Telemetry.Sink.Mimir.Options;
+using HoneyDrunk.Telemetry.Sink.Shared;
 using HoneyDrunk.Vault.Abstractions;
-using HoneyDrunk.Vault.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using System.Net.Http.Headers;
-using System.Text;
 
 namespace HoneyDrunk.Telemetry.Sink.Mimir.Implementation;
 
@@ -40,55 +38,18 @@ public sealed partial class MimirSink(
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
-        if (!_options.Enabled)
-        {
-            return;
-        }
-
-        if (string.IsNullOrEmpty(_options.Endpoint))
-        {
-            LogEndpointNotConfigured();
-            return;
-        }
-
-        var attempt = 0;
-        while (attempt < _options.MaxRetries)
-        {
-            try
-            {
-                using var content = new ByteArrayContent(metricData.ToArray());
-                content.Headers.ContentType = new MediaTypeHeaderValue(contentType);
-                using var request = new HttpRequestMessage(HttpMethod.Post, new Uri(_options.Endpoint!))
-                {
-                    Content = content,
-                };
-
-                await ApplyRequestHeadersAsync(request, cancellationToken).ConfigureAwait(false);
-
-                using var response = await httpClient.SendAsync(request, cancellationToken)
-                    .ConfigureAwait(false);
-
-                if (response.IsSuccessStatusCode)
-                {
-                    LogMetricsExported(metricData.Length);
-                    return;
-                }
-
-                var responseBody = await response.Content
-                    .ReadAsStringAsync(cancellationToken)
-                    .ConfigureAwait(false);
-
-                LogExportFailed((int)response.StatusCode, responseBody);
-                attempt++;
-            }
-            catch (HttpRequestException ex) when (attempt < _options.MaxRetries - 1)
-            {
-                LogExportRetry(attempt + 1, _options.MaxRetries, ex.Message);
-                attempt++;
-                await Task.Delay(TimeSpan.FromMilliseconds(100 * Math.Pow(2, attempt)), cancellationToken)
-                    .ConfigureAwait(false);
-            }
-        }
+        await HttpOtlpSinkExporter.ExportAsync(
+            httpClient,
+            secretStore,
+            _options,
+            metricData,
+            contentType,
+            new HttpOtlpSinkLogCallbacks(
+                LogMetricsExported,
+                LogExportFailed,
+                LogExportRetry,
+                LogEndpointNotConfigured),
+            cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -132,64 +93,4 @@ public sealed partial class MimirSink(
         Level = LogLevel.Warning,
         Message = "Mimir endpoint not configured, skipping export")]
     private partial void LogEndpointNotConfigured();
-
-    private async Task ApplyRequestHeadersAsync(
-        HttpRequestMessage request,
-        CancellationToken cancellationToken)
-    {
-        foreach (var header in _options.Headers)
-        {
-            request.Headers.TryAddWithoutValidation(header.Key, header.Value);
-        }
-
-        var basicAuth = await TryGetSecretValueAsync(_options.BasicAuthSecretName, cancellationToken)
-            .ConfigureAwait(false);
-        if (!string.IsNullOrWhiteSpace(basicAuth))
-        {
-            request.Headers.Authorization = BuildBasicAuthHeader(basicAuth);
-            return;
-        }
-
-        var username = await TryGetSecretValueAsync(_options.UsernameSecretName, cancellationToken)
-            .ConfigureAwait(false);
-        var password = await TryGetSecretValueAsync(_options.PasswordSecretName, cancellationToken)
-            .ConfigureAwait(false);
-        if (!string.IsNullOrWhiteSpace(username) && !string.IsNullOrWhiteSpace(password))
-        {
-            request.Headers.Authorization = BuildBasicAuthHeader($"{username}:{password}");
-        }
-    }
-
-    private async Task<string?> TryGetSecretValueAsync(string secretName, CancellationToken cancellationToken)
-    {
-        if (string.IsNullOrWhiteSpace(secretName))
-        {
-            return null;
-        }
-
-        var result = await secretStore
-            .TryGetSecretAsync(new SecretIdentifier(secretName), cancellationToken)
-            .ConfigureAwait(false);
-
-        return result.IsSuccess ? result.Value?.Value : null;
-    }
-
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "StyleCop.CSharp.OrderingRules",
-        "SA1204:Static elements should appear before instance elements",
-        Justification = "Helper kept adjacent to its only caller TryGetSecretValueAsync for readability.")]
-    private static AuthenticationHeaderValue BuildBasicAuthHeader(string value)
-    {
-        if (AuthenticationHeaderValue.TryParse(value, out var parsed)
-            && !string.IsNullOrWhiteSpace(parsed.Scheme))
-        {
-            return parsed;
-        }
-
-        var parameter = value.Contains(':', StringComparison.Ordinal)
-            ? Convert.ToBase64String(Encoding.UTF8.GetBytes(value))
-            : value;
-
-        return new AuthenticationHeaderValue("Basic", parameter);
-    }
 }

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Mimir/Options/MimirSinkOptions.cs
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Mimir/Options/MimirSinkOptions.cs
@@ -2,12 +2,14 @@
 // Copyright (c) HoneyDrunk Studios. All rights reserved.
 // </copyright>
 
+using HoneyDrunk.Telemetry.Sink.Shared;
+
 namespace HoneyDrunk.Telemetry.Sink.Mimir.Options;
 
 /// <summary>
 /// Configuration options for the Mimir metrics sink.
 /// </summary>
-public sealed class MimirSinkOptions
+public sealed class MimirSinkOptions : IHttpOtlpSinkOptions
 {
     /// <summary>
     /// The configuration section name.

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Mimir/Options/MimirSinkOptions.cs
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Mimir/Options/MimirSinkOptions.cs
@@ -2,14 +2,12 @@
 // Copyright (c) HoneyDrunk Studios. All rights reserved.
 // </copyright>
 
-using HoneyDrunk.Telemetry.Sink.Shared;
-
 namespace HoneyDrunk.Telemetry.Sink.Mimir.Options;
 
 /// <summary>
 /// Configuration options for the Mimir metrics sink.
 /// </summary>
-public sealed class MimirSinkOptions : IHttpOtlpSinkOptions
+public sealed class MimirSinkOptions
 {
     /// <summary>
     /// The configuration section name.

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.PostHog/CHANGELOG.md
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.PostHog/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to HoneyDrunk.Telemetry.Sink.PostHog will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-05-18
+
+### Changed
+
+- Aligned package version to 0.3.0 for the coordinated Kernel adoption release.
+
 ## [0.2.0] - 2026-05-04
 
 ### Changed

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.PostHog/HoneyDrunk.Telemetry.Sink.PostHog.csproj
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.PostHog/HoneyDrunk.Telemetry.Sink.PostHog.csproj
@@ -8,10 +8,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Telemetry.Sink.PostHog</PackageId>
-    <Version>0.2.0</Version>
+    <Version>0.3.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>PostHog analytics sink for HoneyDrunk telemetry. Captures product analytics events with batching, retry logic, and rate-limit handling.</Description>
-    <PackageReleaseNotes>v0.1.0: Initial release. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.3.0: Kernel adoption alignment and HTTP OTLP sink helper consolidation. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>telemetry;sink;posthog;analytics;product-analytics;events;batching</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Sentry/CHANGELOG.md
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Sentry/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to HoneyDrunk.Telemetry.Sink.Sentry will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-05-18
+
+### Changed
+
+- Aligned package version to 0.3.0 for the coordinated Kernel adoption release.
+
 ## [0.2.0] - 2026-05-04
 
 ### Changed

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Sentry/HoneyDrunk.Telemetry.Sink.Sentry.csproj
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Sentry/HoneyDrunk.Telemetry.Sink.Sentry.csproj
@@ -8,10 +8,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Telemetry.Sink.Sentry</PackageId>
-    <Version>0.2.0</Version>
+    <Version>0.3.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Sentry error tracking sink for HoneyDrunk telemetry. Routes error events, exceptions, and error spans to Sentry with enriched Grid context.</Description>
-    <PackageReleaseNotes>v0.1.0: Initial release. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.3.0: Kernel adoption alignment and HTTP OTLP sink helper consolidation. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>telemetry;sink;sentry;errors;error-tracking;exceptions;observability</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Shared/HttpOtlpSinkExporter.cs
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Shared/HttpOtlpSinkExporter.cs
@@ -1,0 +1,155 @@
+// <copyright file="HttpOtlpSinkExporter.cs" company="HoneyDrunk Studios">
+// Copyright (c) HoneyDrunk Studios. All rights reserved.
+// </copyright>
+
+using HoneyDrunk.Vault.Abstractions;
+using HoneyDrunk.Vault.Models;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace HoneyDrunk.Telemetry.Sink.Shared;
+
+/// <summary>
+/// Shared HTTP OTLP export/auth/retry behavior for Grafana-family sinks.
+/// </summary>
+internal static class HttpOtlpSinkExporter
+{
+    /// <summary>
+    /// Exports OTLP payload data to the configured HTTP endpoint.
+    /// </summary>
+    /// <param name="httpClient">The HTTP client.</param>
+    /// <param name="secretStore">The Vault secret store.</param>
+    /// <param name="options">The shared HTTP OTLP options.</param>
+    /// <param name="payload">The OTLP payload.</param>
+    /// <param name="contentType">The payload content type.</param>
+    /// <param name="callbacks">Sink-specific logging callbacks.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous export.</returns>
+    public static async Task ExportAsync(
+        HttpClient httpClient,
+        ISecretStore secretStore,
+        IHttpOtlpSinkOptions options,
+        ReadOnlyMemory<byte> payload,
+        string contentType,
+        HttpOtlpSinkLogCallbacks callbacks,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(secretStore);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(callbacks);
+
+        if (!options.Enabled)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(options.Endpoint))
+        {
+            callbacks.EndpointNotConfigured();
+            return;
+        }
+
+        var maxRetries = Math.Max(1, options.MaxRetries);
+        for (var attempt = 0; attempt < maxRetries; attempt++)
+        {
+            try
+            {
+                using var content = new ByteArrayContent(payload.ToArray());
+                content.Headers.ContentType = new MediaTypeHeaderValue(contentType);
+                using var request = new HttpRequestMessage(HttpMethod.Post, new Uri(options.Endpoint, UriKind.Absolute))
+                {
+                    Content = content,
+                };
+
+                await ApplyRequestHeadersAsync(request, secretStore, options, cancellationToken)
+                    .ConfigureAwait(false);
+
+                using var response = await httpClient.SendAsync(request, cancellationToken)
+                    .ConfigureAwait(false);
+
+                if (response.IsSuccessStatusCode)
+                {
+                    callbacks.Exported(payload.Length);
+                    return;
+                }
+
+                var responseBody = await response.Content
+                    .ReadAsStringAsync(cancellationToken)
+                    .ConfigureAwait(false);
+
+                callbacks.ExportFailed((int)response.StatusCode, responseBody);
+            }
+            catch (HttpRequestException ex) when (attempt < maxRetries - 1)
+            {
+                callbacks.ExportRetry(attempt + 1, maxRetries, ex.Message);
+                await Task.Delay(GetRetryDelay(attempt + 1), cancellationToken)
+                    .ConfigureAwait(false);
+            }
+        }
+    }
+
+    private static async Task ApplyRequestHeadersAsync(
+        HttpRequestMessage request,
+        ISecretStore secretStore,
+        IHttpOtlpSinkOptions options,
+        CancellationToken cancellationToken)
+    {
+        foreach (var header in options.Headers)
+        {
+            request.Headers.TryAddWithoutValidation(header.Key, header.Value);
+        }
+
+        var basicAuth = await TryGetSecretValueAsync(secretStore, options.BasicAuthSecretName, cancellationToken)
+            .ConfigureAwait(false);
+        if (!string.IsNullOrWhiteSpace(basicAuth))
+        {
+            request.Headers.Authorization = BuildBasicAuthHeader(basicAuth);
+            return;
+        }
+
+        var username = await TryGetSecretValueAsync(secretStore, options.UsernameSecretName, cancellationToken)
+            .ConfigureAwait(false);
+        var password = await TryGetSecretValueAsync(secretStore, options.PasswordSecretName, cancellationToken)
+            .ConfigureAwait(false);
+        if (!string.IsNullOrWhiteSpace(username) && !string.IsNullOrWhiteSpace(password))
+        {
+            request.Headers.Authorization = BuildBasicAuthHeader($"{username}:{password}");
+        }
+    }
+
+    private static async Task<string?> TryGetSecretValueAsync(
+        ISecretStore secretStore,
+        string secretName,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(secretName))
+        {
+            return null;
+        }
+
+        var result = await secretStore
+            .TryGetSecretAsync(new SecretIdentifier(secretName), cancellationToken)
+            .ConfigureAwait(false);
+
+        return result.IsSuccess ? result.Value?.Value : null;
+    }
+
+    private static AuthenticationHeaderValue BuildBasicAuthHeader(string value)
+    {
+        if (AuthenticationHeaderValue.TryParse(value, out var parsed)
+            && !string.IsNullOrWhiteSpace(parsed.Scheme))
+        {
+            return parsed;
+        }
+
+        var parameter = value.Contains(':', StringComparison.Ordinal)
+            ? Convert.ToBase64String(Encoding.UTF8.GetBytes(value))
+            : value;
+
+        return new AuthenticationHeaderValue("Basic", parameter);
+    }
+
+    private static TimeSpan GetRetryDelay(int attempt) =>
+        TimeSpan.FromMilliseconds(100 * Math.Pow(2, attempt));
+}

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Shared/HttpOtlpSinkLogCallbacks.cs
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Shared/HttpOtlpSinkLogCallbacks.cs
@@ -1,0 +1,50 @@
+// <copyright file="HttpOtlpSinkLogCallbacks.cs" company="HoneyDrunk Studios">
+// Copyright (c) HoneyDrunk Studios. All rights reserved.
+// </copyright>
+
+namespace HoneyDrunk.Telemetry.Sink.Shared;
+
+/// <summary>
+/// Sink-specific logging callbacks used by the shared HTTP OTLP exporter.
+/// </summary>
+internal sealed class HttpOtlpSinkLogCallbacks
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HttpOtlpSinkLogCallbacks"/> class.
+    /// </summary>
+    /// <param name="exported">Called when an export succeeds.</param>
+    /// <param name="exportFailed">Called when an export receives an unsuccessful response.</param>
+    /// <param name="exportRetry">Called before a retry after a transient HTTP failure.</param>
+    /// <param name="endpointNotConfigured">Called when the sink endpoint is missing.</param>
+    public HttpOtlpSinkLogCallbacks(
+        Action<int> exported,
+        Action<int, string> exportFailed,
+        Action<int, int, string> exportRetry,
+        Action endpointNotConfigured)
+    {
+        Exported = exported;
+        ExportFailed = exportFailed;
+        ExportRetry = exportRetry;
+        EndpointNotConfigured = endpointNotConfigured;
+    }
+
+    /// <summary>
+    /// Gets the success callback.
+    /// </summary>
+    public Action<int> Exported { get; }
+
+    /// <summary>
+    /// Gets the unsuccessful-response callback.
+    /// </summary>
+    public Action<int, string> ExportFailed { get; }
+
+    /// <summary>
+    /// Gets the retry callback.
+    /// </summary>
+    public Action<int, int, string> ExportRetry { get; }
+
+    /// <summary>
+    /// Gets the missing-endpoint callback.
+    /// </summary>
+    public Action EndpointNotConfigured { get; }
+}

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Shared/HttpOtlpSinkOptionsAdapter.cs
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Shared/HttpOtlpSinkOptionsAdapter.cs
@@ -1,0 +1,66 @@
+// <copyright file="HttpOtlpSinkOptionsAdapter.cs" company="HoneyDrunk Studios">
+// Copyright (c) HoneyDrunk Studios. All rights reserved.
+// </copyright>
+
+namespace HoneyDrunk.Telemetry.Sink.Shared;
+
+/// <summary>
+/// Internal adapter for shared HTTP OTLP sink option values.
+/// </summary>
+internal sealed class HttpOtlpSinkOptionsAdapter : IHttpOtlpSinkOptions
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HttpOtlpSinkOptionsAdapter"/> class.
+    /// </summary>
+    /// <param name="endpoint">The OTLP endpoint URL.</param>
+    /// <param name="enabled">A value indicating whether the sink is enabled.</param>
+    /// <param name="timeoutSeconds">The HTTP client timeout in seconds.</param>
+    /// <param name="maxRetries">The maximum number of retry attempts.</param>
+    /// <param name="headers">Optional custom headers to include in requests.</param>
+    /// <param name="basicAuthSecretName">The Vault secret name for an Authorization header or Basic auth value.</param>
+    /// <param name="usernameSecretName">The Vault secret name for the basic auth username.</param>
+    /// <param name="passwordSecretName">The Vault secret name for the basic auth password.</param>
+    public HttpOtlpSinkOptionsAdapter(
+        string? endpoint,
+        bool enabled,
+        int timeoutSeconds,
+        int maxRetries,
+        Dictionary<string, string> headers,
+        string basicAuthSecretName,
+        string usernameSecretName,
+        string passwordSecretName)
+    {
+        Endpoint = endpoint;
+        Enabled = enabled;
+        TimeoutSeconds = timeoutSeconds;
+        MaxRetries = maxRetries;
+        Headers = headers;
+        BasicAuthSecretName = basicAuthSecretName;
+        UsernameSecretName = usernameSecretName;
+        PasswordSecretName = passwordSecretName;
+    }
+
+    /// <inheritdoc />
+    public string? Endpoint { get; }
+
+    /// <inheritdoc />
+    public bool Enabled { get; }
+
+    /// <inheritdoc />
+    public int TimeoutSeconds { get; }
+
+    /// <inheritdoc />
+    public int MaxRetries { get; }
+
+    /// <inheritdoc />
+    public Dictionary<string, string> Headers { get; }
+
+    /// <inheritdoc />
+    public string BasicAuthSecretName { get; }
+
+    /// <inheritdoc />
+    public string UsernameSecretName { get; }
+
+    /// <inheritdoc />
+    public string PasswordSecretName { get; }
+}

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Shared/IHttpOtlpSinkOptions.cs
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Shared/IHttpOtlpSinkOptions.cs
@@ -1,0 +1,51 @@
+// <copyright file="HttpOtlpSinkOptions.cs" company="HoneyDrunk Studios">
+// Copyright (c) HoneyDrunk Studios. All rights reserved.
+// </copyright>
+
+namespace HoneyDrunk.Telemetry.Sink.Shared;
+
+/// <summary>
+/// Shared HTTP OTLP sink option shape used by Grafana-family sinks.
+/// </summary>
+public interface IHttpOtlpSinkOptions
+{
+    /// <summary>
+    /// Gets the OTLP endpoint URL.
+    /// </summary>
+    string? Endpoint { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the sink is enabled.
+    /// </summary>
+    bool Enabled { get; }
+
+    /// <summary>
+    /// Gets the HTTP client timeout in seconds.
+    /// </summary>
+    int TimeoutSeconds { get; }
+
+    /// <summary>
+    /// Gets the maximum number of retry attempts.
+    /// </summary>
+    int MaxRetries { get; }
+
+    /// <summary>
+    /// Gets optional custom headers to include in requests.
+    /// </summary>
+    Dictionary<string, string> Headers { get; }
+
+    /// <summary>
+    /// Gets the Vault secret name for the Authorization header or Basic auth value.
+    /// </summary>
+    string BasicAuthSecretName { get; }
+
+    /// <summary>
+    /// Gets the Vault secret name for the basic auth username.
+    /// </summary>
+    string UsernameSecretName { get; }
+
+    /// <summary>
+    /// Gets the Vault secret name for the basic auth password.
+    /// </summary>
+    string PasswordSecretName { get; }
+}

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Shared/IHttpOtlpSinkOptions.cs
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Shared/IHttpOtlpSinkOptions.cs
@@ -1,4 +1,4 @@
-// <copyright file="HttpOtlpSinkOptions.cs" company="HoneyDrunk Studios">
+// <copyright file="IHttpOtlpSinkOptions.cs" company="HoneyDrunk Studios">
 // Copyright (c) HoneyDrunk Studios. All rights reserved.
 // </copyright>
 
@@ -7,7 +7,7 @@ namespace HoneyDrunk.Telemetry.Sink.Shared;
 /// <summary>
 /// Shared HTTP OTLP sink option shape used by Grafana-family sinks.
 /// </summary>
-public interface IHttpOtlpSinkOptions
+internal interface IHttpOtlpSinkOptions
 {
     /// <summary>
     /// Gets the OTLP endpoint URL.

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Tempo/CHANGELOG.md
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Tempo/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to HoneyDrunk.Telemetry.Sink.Tempo will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-05-18
+
+### Changed
+
+- Consolidated HTTP OTLP export, custom header, Vault-backed authorization, and retry behavior through the shared Grafana-family sink helper while preserving Tempo-specific defaults and logging.
+
 ## [0.2.0] - 2026-05-04
 
 ### Changed

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Tempo/HoneyDrunk.Telemetry.Sink.Tempo.csproj
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Tempo/HoneyDrunk.Telemetry.Sink.Tempo.csproj
@@ -8,10 +8,10 @@
 
     <!-- Package Metadata -->
     <PackageId>HoneyDrunk.Telemetry.Sink.Tempo</PackageId>
-    <Version>0.2.0</Version>
+    <Version>0.3.0</Version>
     <Authors>HoneyDrunk Studios</Authors>
     <Description>Grafana Tempo trace sink for HoneyDrunk telemetry. Forwards OTLP trace data to Tempo for distributed trace storage and querying.</Description>
-    <PackageReleaseNotes>v0.1.0: Initial release. See CHANGELOG.md for details.</PackageReleaseNotes>
+    <PackageReleaseNotes>v0.3.0: Kernel adoption alignment and HTTP OTLP sink helper consolidation. See CHANGELOG.md for details.</PackageReleaseNotes>
     <PackageTags>telemetry;sink;tempo;grafana;traces;tracing;distributed-tracing;observability</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -44,6 +44,12 @@
 
   <ItemGroup>
     <ProjectReference Include="..\HoneyDrunk.Telemetry.Abstractions\HoneyDrunk.Telemetry.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\HoneyDrunk.Telemetry.Sink.Shared\HttpOtlpSinkExporter.cs" Link="Shared\HttpOtlpSinkExporter.cs" />
+    <Compile Include="..\HoneyDrunk.Telemetry.Sink.Shared\HttpOtlpSinkLogCallbacks.cs" Link="Shared\HttpOtlpSinkLogCallbacks.cs" />
+    <Compile Include="..\HoneyDrunk.Telemetry.Sink.Shared\IHttpOtlpSinkOptions.cs" Link="Shared\IHttpOtlpSinkOptions.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Tempo/HoneyDrunk.Telemetry.Sink.Tempo.csproj
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Tempo/HoneyDrunk.Telemetry.Sink.Tempo.csproj
@@ -49,6 +49,7 @@
   <ItemGroup>
     <Compile Include="..\HoneyDrunk.Telemetry.Sink.Shared\HttpOtlpSinkExporter.cs" Link="Shared\HttpOtlpSinkExporter.cs" />
     <Compile Include="..\HoneyDrunk.Telemetry.Sink.Shared\HttpOtlpSinkLogCallbacks.cs" Link="Shared\HttpOtlpSinkLogCallbacks.cs" />
+    <Compile Include="..\HoneyDrunk.Telemetry.Sink.Shared\HttpOtlpSinkOptionsAdapter.cs" Link="Shared\HttpOtlpSinkOptionsAdapter.cs" />
     <Compile Include="..\HoneyDrunk.Telemetry.Sink.Shared\IHttpOtlpSinkOptions.cs" Link="Shared\IHttpOtlpSinkOptions.cs" />
   </ItemGroup>
 

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Tempo/Implementation/TempoSink.cs
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Tempo/Implementation/TempoSink.cs
@@ -41,7 +41,15 @@ public sealed partial class TempoSink(
         await HttpOtlpSinkExporter.ExportAsync(
             httpClient,
             secretStore,
-            _options,
+            new HttpOtlpSinkOptionsAdapter(
+                _options.Endpoint,
+                _options.Enabled,
+                _options.TimeoutSeconds,
+                _options.MaxRetries,
+                _options.Headers,
+                _options.BasicAuthSecretName,
+                _options.UsernameSecretName,
+                _options.PasswordSecretName),
             traceData,
             contentType,
             new HttpOtlpSinkLogCallbacks(

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Tempo/Implementation/TempoSink.cs
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Tempo/Implementation/TempoSink.cs
@@ -3,13 +3,11 @@
 // </copyright>
 
 using HoneyDrunk.Telemetry.Abstractions.Abstractions;
+using HoneyDrunk.Telemetry.Sink.Shared;
 using HoneyDrunk.Telemetry.Sink.Tempo.Options;
 using HoneyDrunk.Vault.Abstractions;
-using HoneyDrunk.Vault.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using System.Net.Http.Headers;
-using System.Text;
 
 namespace HoneyDrunk.Telemetry.Sink.Tempo.Implementation;
 
@@ -40,55 +38,18 @@ public sealed partial class TempoSink(
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
-        if (!_options.Enabled)
-        {
-            return;
-        }
-
-        if (string.IsNullOrEmpty(_options.Endpoint))
-        {
-            LogEndpointNotConfigured();
-            return;
-        }
-
-        var attempt = 0;
-        while (attempt < _options.MaxRetries)
-        {
-            try
-            {
-                using var content = new ByteArrayContent(traceData.ToArray());
-                content.Headers.ContentType = new MediaTypeHeaderValue(contentType);
-                using var request = new HttpRequestMessage(HttpMethod.Post, new Uri(_options.Endpoint!))
-                {
-                    Content = content,
-                };
-
-                await ApplyRequestHeadersAsync(request, cancellationToken).ConfigureAwait(false);
-
-                using var response = await httpClient.SendAsync(request, cancellationToken)
-                    .ConfigureAwait(false);
-
-                if (response.IsSuccessStatusCode)
-                {
-                    LogTracesExported(traceData.Length);
-                    return;
-                }
-
-                var responseBody = await response.Content
-                    .ReadAsStringAsync(cancellationToken)
-                    .ConfigureAwait(false);
-
-                LogExportFailed((int)response.StatusCode, responseBody);
-                attempt++;
-            }
-            catch (HttpRequestException ex) when (attempt < _options.MaxRetries - 1)
-            {
-                LogExportRetry(attempt + 1, _options.MaxRetries, ex.Message);
-                attempt++;
-                await Task.Delay(TimeSpan.FromMilliseconds(100 * Math.Pow(2, attempt)), cancellationToken)
-                    .ConfigureAwait(false);
-            }
-        }
+        await HttpOtlpSinkExporter.ExportAsync(
+            httpClient,
+            secretStore,
+            _options,
+            traceData,
+            contentType,
+            new HttpOtlpSinkLogCallbacks(
+                LogTracesExported,
+                LogExportFailed,
+                LogExportRetry,
+                LogEndpointNotConfigured),
+            cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -132,64 +93,4 @@ public sealed partial class TempoSink(
         Level = LogLevel.Warning,
         Message = "Tempo endpoint not configured, skipping export")]
     private partial void LogEndpointNotConfigured();
-
-    private async Task ApplyRequestHeadersAsync(
-        HttpRequestMessage request,
-        CancellationToken cancellationToken)
-    {
-        foreach (var header in _options.Headers)
-        {
-            request.Headers.TryAddWithoutValidation(header.Key, header.Value);
-        }
-
-        var basicAuth = await TryGetSecretValueAsync(_options.BasicAuthSecretName, cancellationToken)
-            .ConfigureAwait(false);
-        if (!string.IsNullOrWhiteSpace(basicAuth))
-        {
-            request.Headers.Authorization = BuildBasicAuthHeader(basicAuth);
-            return;
-        }
-
-        var username = await TryGetSecretValueAsync(_options.UsernameSecretName, cancellationToken)
-            .ConfigureAwait(false);
-        var password = await TryGetSecretValueAsync(_options.PasswordSecretName, cancellationToken)
-            .ConfigureAwait(false);
-        if (!string.IsNullOrWhiteSpace(username) && !string.IsNullOrWhiteSpace(password))
-        {
-            request.Headers.Authorization = BuildBasicAuthHeader($"{username}:{password}");
-        }
-    }
-
-    private async Task<string?> TryGetSecretValueAsync(string secretName, CancellationToken cancellationToken)
-    {
-        if (string.IsNullOrWhiteSpace(secretName))
-        {
-            return null;
-        }
-
-        var result = await secretStore
-            .TryGetSecretAsync(new SecretIdentifier(secretName), cancellationToken)
-            .ConfigureAwait(false);
-
-        return result.IsSuccess ? result.Value?.Value : null;
-    }
-
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(
-        "StyleCop.CSharp.OrderingRules",
-        "SA1204:Static elements should appear before instance elements",
-        Justification = "Helper kept adjacent to its only caller TryGetSecretValueAsync for readability.")]
-    private static AuthenticationHeaderValue BuildBasicAuthHeader(string value)
-    {
-        if (AuthenticationHeaderValue.TryParse(value, out var parsed)
-            && !string.IsNullOrWhiteSpace(parsed.Scheme))
-        {
-            return parsed;
-        }
-
-        var parameter = value.Contains(':', StringComparison.Ordinal)
-            ? Convert.ToBase64String(Encoding.UTF8.GetBytes(value))
-            : value;
-
-        return new AuthenticationHeaderValue("Basic", parameter);
-    }
 }

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Tempo/Options/TempoSinkOptions.cs
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Tempo/Options/TempoSinkOptions.cs
@@ -2,12 +2,14 @@
 // Copyright (c) HoneyDrunk Studios. All rights reserved.
 // </copyright>
 
+using HoneyDrunk.Telemetry.Sink.Shared;
+
 namespace HoneyDrunk.Telemetry.Sink.Tempo.Options;
 
 /// <summary>
 /// Configuration options for the Tempo trace sink.
 /// </summary>
-public sealed class TempoSinkOptions
+public sealed class TempoSinkOptions : IHttpOtlpSinkOptions
 {
     /// <summary>
     /// The configuration section name.

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Tempo/Options/TempoSinkOptions.cs
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Tempo/Options/TempoSinkOptions.cs
@@ -2,14 +2,12 @@
 // Copyright (c) HoneyDrunk Studios. All rights reserved.
 // </copyright>
 
-using HoneyDrunk.Telemetry.Sink.Shared;
-
 namespace HoneyDrunk.Telemetry.Sink.Tempo.Options;
 
 /// <summary>
 /// Configuration options for the Tempo trace sink.
 /// </summary>
-public sealed class TempoSinkOptions : IHttpOtlpSinkOptions
+public sealed class TempoSinkOptions
 {
     /// <summary>
     /// The configuration section name.

--- a/HoneyDrunk.Pulse/Pulse.Collector/HoneyDrunk.Pulse.Collector.csproj
+++ b/HoneyDrunk.Pulse/Pulse.Collector/HoneyDrunk.Pulse.Collector.csproj
@@ -16,14 +16,14 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="HoneyDrunk.Kernel" Version="0.4.0" />
+    <PackageReference Include="HoneyDrunk.Kernel" Version="0.7.0" />
     <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="HoneyDrunk.Transport" Version="0.4.0" />
-    <PackageReference Include="HoneyDrunk.Transport.AzureServiceBus" Version="0.4.0" />
-    <PackageReference Include="HoneyDrunk.Transport.InMemory" Version="0.4.0" />
+    <PackageReference Include="HoneyDrunk.Transport" Version="0.6.0" />
+    <PackageReference Include="HoneyDrunk.Transport.AzureServiceBus" Version="0.6.0" />
+    <PackageReference Include="HoneyDrunk.Transport.InMemory" Version="0.6.0" />
     <PackageReference Include="HoneyDrunk.Vault" Version="0.3.0" />
     <PackageReference Include="HoneyDrunk.Vault.EventGrid" Version="0.3.0" />
     <PackageReference Include="HoneyDrunk.Vault.Providers.AppConfiguration" Version="0.3.0" />

--- a/HoneyDrunk.Pulse/Pulse.Collector/Program.cs
+++ b/HoneyDrunk.Pulse/Pulse.Collector/Program.cs
@@ -2,6 +2,7 @@
 // Copyright (c) HoneyDrunk Studios. All rights reserved.
 // </copyright>
 
+using HoneyDrunk.Kernel.Abstractions;
 using HoneyDrunk.Kernel.Abstractions.Identity;
 using HoneyDrunk.Kernel.Hosting;
 using HoneyDrunk.Pulse.Collector.Configuration;
@@ -41,12 +42,12 @@ public class Program
     {
         var builder = WebApplication.CreateBuilder(args);
 
-        builder.Configuration["HONEYDRUNK_NODE_ID"] ??= "pulse";
+        builder.Configuration["HONEYDRUNK_NODE_ID"] ??= WellKnownNodes.Ops.Pulse.Value;
         builder.Services.Replace(ServiceDescriptor.Singleton<IConfiguration>(builder.Configuration));
 
         builder.Services.AddHoneyDrunkNode(options =>
         {
-            options.NodeId = new NodeId("pulse");
+            options.NodeId = new NodeId(builder.Configuration["HONEYDRUNK_NODE_ID"] ?? WellKnownNodes.Ops.Pulse.Value);
             options.SectorId = SectorId.WellKnown.Ops;
             options.StudioId = "honeydrunk";
             options.EnvironmentId = new EnvironmentId(builder.Environment.EnvironmentName.ToLowerInvariant());

--- a/HoneyDrunk.Pulse/Pulse.Tests/Collector/CollectorSmokeTests.cs
+++ b/HoneyDrunk.Pulse/Pulse.Tests/Collector/CollectorSmokeTests.cs
@@ -38,6 +38,24 @@ public class CollectorSmokeTests(CollectorWebApplicationFactory factory) : IClas
     }
 
     /// <summary>
+    /// Verifies that deploy-time node ID configuration overrides the canonical fallback.
+    /// </summary>
+    [Fact]
+    public void CollectorNodeContext_ShouldUseConfiguredNodeIdOverride()
+    {
+        // Arrange
+        const string configuredNodeId = "honeydrunk-pulse-canary";
+        using var overrideFactory = CollectorWebApplicationFactory.CreateWithNodeId(configuredNodeId);
+        using var scope = overrideFactory.Services.CreateScope();
+
+        // Act
+        var nodeContext = scope.ServiceProvider.GetRequiredService<INodeContext>();
+
+        // Assert
+        nodeContext.NodeId.Should().Be(configuredNodeId);
+    }
+
+    /// <summary>
     /// Verifies that the health endpoint returns OK.
     /// </summary>
     /// <returns>A task representing the asynchronous test.</returns>

--- a/HoneyDrunk.Pulse/Pulse.Tests/Collector/CollectorSmokeTests.cs
+++ b/HoneyDrunk.Pulse/Pulse.Tests/Collector/CollectorSmokeTests.cs
@@ -3,6 +3,9 @@
 // </copyright>
 
 using FluentAssertions;
+using HoneyDrunk.Kernel.Abstractions;
+using HoneyDrunk.Kernel.Abstractions.Context;
+using Microsoft.Extensions.DependencyInjection;
 using System.Net;
 using System.Net.Http.Json;
 
@@ -18,6 +21,22 @@ namespace HoneyDrunk.Pulse.Tests.Collector;
 [Collection(CollectorEnvVarCollection.CollectionName)]
 public class CollectorSmokeTests(CollectorWebApplicationFactory factory) : IClassFixture<CollectorWebApplicationFactory>
 {
+    /// <summary>
+    /// Verifies that the collector defaults to Kernel's canonical Pulse Node ID.
+    /// </summary>
+    [Fact]
+    public void CollectorNodeContext_ShouldUseCanonicalPulseNodeIdFallback()
+    {
+        // Arrange
+        using var scope = factory.Services.CreateScope();
+
+        // Act
+        var nodeContext = scope.ServiceProvider.GetRequiredService<INodeContext>();
+
+        // Assert
+        nodeContext.NodeId.Should().Be(WellKnownNodes.Ops.Pulse.Value);
+    }
+
     /// <summary>
     /// Verifies that the health endpoint returns OK.
     /// </summary>

--- a/HoneyDrunk.Pulse/Pulse.Tests/Collector/CollectorWebApplicationFactory.cs
+++ b/HoneyDrunk.Pulse/Pulse.Tests/Collector/CollectorWebApplicationFactory.cs
@@ -27,6 +27,11 @@ public class CollectorWebApplicationFactory : WebApplicationFactory<Program>
     /// Initializes a new instance of the <see cref="CollectorWebApplicationFactory"/> class.
     /// </summary>
     public CollectorWebApplicationFactory()
+        : this(null)
+    {
+    }
+
+    private CollectorWebApplicationFactory(string? honeyDrunkNodeId)
     {
         _previousAspNetCoreEnvironment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
         _previousDotNetEnvironment = Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT");
@@ -38,8 +43,16 @@ public class CollectorWebApplicationFactory : WebApplicationFactory<Program>
         Environment.SetEnvironmentVariable("DOTNET_ENVIRONMENT", "Development");
         Environment.SetEnvironmentVariable("AZURE_KEYVAULT_URI", null);
         Environment.SetEnvironmentVariable("AZURE_APPCONFIG_ENDPOINT", null);
-        Environment.SetEnvironmentVariable("HONEYDRUNK_NODE_ID", null);
+        Environment.SetEnvironmentVariable("HONEYDRUNK_NODE_ID", honeyDrunkNodeId);
     }
+
+    /// <summary>
+    /// Creates a factory with a configured node ID override.
+    /// </summary>
+    /// <param name="honeyDrunkNodeId">The node ID override.</param>
+    /// <returns>A collector web application factory configured with the provided node ID.</returns>
+    public static CollectorWebApplicationFactory CreateWithNodeId(string honeyDrunkNodeId) =>
+        new(honeyDrunkNodeId);
 
     /// <inheritdoc/>
     protected override void Dispose(bool disposing)

--- a/HoneyDrunk.Pulse/Pulse.Tests/HoneyDrunk.Pulse.Tests.csproj
+++ b/HoneyDrunk.Pulse/Pulse.Tests/HoneyDrunk.Pulse.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -30,8 +30,11 @@
   <ItemGroup>
     <ProjectReference Include="..\HoneyDrunk.Pulse.Contracts\HoneyDrunk.Pulse.Contracts.csproj" />
     <ProjectReference Include="..\HoneyDrunk.Telemetry.Abstractions\HoneyDrunk.Telemetry.Abstractions.csproj" />
+    <ProjectReference Include="..\HoneyDrunk.Telemetry.Sink.Loki\HoneyDrunk.Telemetry.Sink.Loki.csproj" />
+    <ProjectReference Include="..\HoneyDrunk.Telemetry.Sink.Mimir\HoneyDrunk.Telemetry.Sink.Mimir.csproj" />
     <ProjectReference Include="..\HoneyDrunk.Telemetry.Sink.PostHog\HoneyDrunk.Telemetry.Sink.PostHog.csproj" />
     <ProjectReference Include="..\HoneyDrunk.Telemetry.Sink.Sentry\HoneyDrunk.Telemetry.Sink.Sentry.csproj" />
+    <ProjectReference Include="..\HoneyDrunk.Telemetry.Sink.Tempo\HoneyDrunk.Telemetry.Sink.Tempo.csproj" />
     <ProjectReference Include="..\Pulse.Collector\HoneyDrunk.Pulse.Collector.csproj" />
   </ItemGroup>
 

--- a/HoneyDrunk.Pulse/Pulse.Tests/Telemetry/HttpOtlpSinkExporterTests.cs
+++ b/HoneyDrunk.Pulse/Pulse.Tests/Telemetry/HttpOtlpSinkExporterTests.cs
@@ -1,0 +1,174 @@
+// <copyright file="HttpOtlpSinkExporterTests.cs" company="HoneyDrunk Studios">
+// Copyright (c) HoneyDrunk Studios. All rights reserved.
+// </copyright>
+
+using FluentAssertions;
+using HoneyDrunk.Telemetry.Sink.Loki.Implementation;
+using HoneyDrunk.Telemetry.Sink.Loki.Options;
+using HoneyDrunk.Telemetry.Sink.Mimir.Implementation;
+using HoneyDrunk.Telemetry.Sink.Mimir.Options;
+using HoneyDrunk.Telemetry.Sink.Tempo.Implementation;
+using HoneyDrunk.Telemetry.Sink.Tempo.Options;
+using HoneyDrunk.Vault.Abstractions;
+using HoneyDrunk.Vault.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace HoneyDrunk.Pulse.Tests.Telemetry;
+
+/// <summary>
+/// Verifies shared HTTP OTLP sink export behavior through concrete sinks.
+/// </summary>
+public class HttpOtlpSinkExporterTests
+{
+    /// <summary>
+    /// Verifies configured headers and username/password secrets become a Basic auth header.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task LokiExportAsync_ShouldApplyHeadersAndUsernamePasswordBasicAuth()
+    {
+        // Arrange
+        using var handler = new CapturingHandler(_ => new HttpResponseMessage(HttpStatusCode.Accepted));
+        using var httpClient = new HttpClient(handler);
+        var secrets = new StubSecretStore(new Dictionary<string, string>
+        {
+            ["Loki--Username"] = "tenant",
+            ["Loki--Password"] = "password",
+        });
+        using var sink = new LokiSink(
+            httpClient,
+            secrets,
+            Options.Create(new LokiSinkOptions
+            {
+                Endpoint = "https://loki.example/otlp/v1/logs",
+                Headers = { ["X-Scope-OrgID"] = "honeydrunk" },
+            }),
+            NullLogger<LokiSink>.Instance);
+
+        // Act
+        await sink.ExportAsync(Encoding.UTF8.GetBytes("logs"), "application/json");
+
+        // Assert
+        handler.Requests.Should().ContainSingle();
+        var request = handler.Requests[0];
+        request.Headers.GetValues("X-Scope-OrgID").Should().ContainSingle("honeydrunk");
+        request.Headers.Authorization.Should().BeEquivalentTo(
+            new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.UTF8.GetBytes("tenant:password"))));
+    }
+
+    /// <summary>
+    /// Verifies HTTP request failures are retried by the shared exporter.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task MimirExportAsync_ShouldRetryTransientHttpRequestFailures()
+    {
+        // Arrange
+        var attempts = 0;
+        using var handler = new CapturingHandler(_ =>
+        {
+            attempts++;
+            if (attempts == 1)
+            {
+                throw new HttpRequestException("transient");
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        });
+        using var httpClient = new HttpClient(handler);
+        using var sink = new MimirSink(
+            httpClient,
+            new StubSecretStore(),
+            Options.Create(new MimirSinkOptions
+            {
+                Endpoint = "https://mimir.example/otlp/v1/metrics",
+                MaxRetries = 2,
+            }),
+            NullLogger<MimirSink>.Instance);
+
+        // Act
+        await sink.ExportAsync(Encoding.UTF8.GetBytes("metrics"), "application/json");
+
+        // Assert
+        attempts.Should().Be(2);
+        handler.Requests.Should().HaveCount(2);
+    }
+
+    /// <summary>
+    /// Verifies a full Authorization header secret is preserved when supplied.
+    /// </summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Fact]
+    public async Task TempoExportAsync_ShouldPreserveAuthorizationHeaderSecret()
+    {
+        // Arrange
+        using var handler = new CapturingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK));
+        using var httpClient = new HttpClient(handler);
+        using var sink = new TempoSink(
+            httpClient,
+            new StubSecretStore(new Dictionary<string, string>
+            {
+                ["Tempo--BasicAuth"] = "Bearer tempo-token",
+            }),
+            Options.Create(new TempoSinkOptions
+            {
+                Endpoint = "https://tempo.example/v1/traces",
+            }),
+            NullLogger<TempoSink>.Instance);
+
+        // Act
+        await sink.ExportAsync(Encoding.UTF8.GetBytes("traces"), "application/json");
+
+        // Assert
+        handler.Requests.Should().ContainSingle();
+        handler.Requests[0].Headers.Authorization.Should().BeEquivalentTo(
+            new AuthenticationHeaderValue("Bearer", "tempo-token"));
+    }
+
+    private sealed class CapturingHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler
+    {
+        public List<HttpRequestMessage> Requests { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var clone = new HttpRequestMessage(request.Method, request.RequestUri);
+            foreach (var header in request.Headers)
+            {
+                clone.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+
+            Requests.Add(clone);
+            return Task.FromResult(responder(request));
+        }
+    }
+
+    private sealed class StubSecretStore(IReadOnlyDictionary<string, string>? secrets = null) : ISecretStore
+    {
+        private readonly IReadOnlyDictionary<string, string> _secrets = secrets ?? new Dictionary<string, string>();
+
+        public Task<SecretValue> GetSecretAsync(
+            SecretIdentifier identifier,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(new SecretValue(identifier, _secrets[identifier.Name], version: null));
+
+        public Task<VaultResult<SecretValue>> TryGetSecretAsync(
+            SecretIdentifier identifier,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(_secrets.TryGetValue(identifier.Name, out var value)
+                ? VaultResult.Success(new SecretValue(identifier, value, version: null))
+                : VaultResult.Failure<SecretValue>($"Secret '{identifier.Name}' was not found."));
+        }
+
+        public Task<IReadOnlyList<SecretVersion>> ListSecretVersionsAsync(
+            string secretName,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<SecretVersion>>([]);
+    }
+}


### PR DESCRIPTION
## Summary

- align Pulse.Collector with Kernel canonical `WellKnownNodes.Ops.Pulse` (`honeydrunk-pulse`) while preserving `HONEYDRUNK_NODE_ID` overrides
- update Kernel/Transport package references to the published adoption versions and align package metadata/changelogs to `0.3.0`
- consolidate duplicated Loki/Mimir/Tempo HTTP OTLP export, headers, Vault-backed auth, and retry behavior through shared linked helpers
- add collector identity and HTTP OTLP sink coverage for canonical fallback, headers, auth, and retry behavior

Closes #15
Closes #11

## Validation

- `dotnet build HoneyDrunk.Pulse\HoneyDrunk.Pulse.slnx -c Release --no-restore` ✅  
  - warning only: Azure Artifacts vulnerability feed/service-index access (`NU1900`)
- `dotnet test HoneyDrunk.Pulse\HoneyDrunk.Pulse.slnx -c Release --no-build --verbosity minimal` ✅ (`150/150`)
- `dotnet list HoneyDrunk.Pulse\HoneyDrunk.Pulse.slnx package --vulnerable --include-transitive --config <nuget.org-only temp config>` ✅ no vulnerable packages
- `git diff --check` ✅
- lightweight secret pattern scan ✅ no matches (`gitleaks` unavailable/quiet locally)

## Notes

- Previous published repo version was `v0.2.0` / NuGet `0.2.0`; this PR prepares `0.3.0` changelog sections so the release workflow can generate GitHub release notes from the tag.
- No Architecture/Hive sync is included here; Core repo pass continues first.
