### PR TITLE
test: migrate Pulse assertions to AwesomeAssertions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -109,7 +109,7 @@ dotnet test -c Release --no-build
 
 - Targets **.NET 10.0**. Warnings are errors.
 - Tests live only in `Pulse.Tests` — no test code in libraries or the Collector. Prefer
-  **xUnit** + **FluentAssertions**. Test classes mirror implementation.
+  **xUnit** + **AwesomeAssertions**. Test classes mirror implementation.
 - All code changes include tests unless the issue explicitly says otherwise.
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ conventions. Read it before implementing. This file only states agent-execution 
    cross-sink behavior goes in a shared location, not copied per sink. Prefer cohesive
    shared methods over one-off near-duplicates; justify intentional duplication in a
    comment. DRY/SOLID.
-5. Add or update tests in `Pulse.Tests` (xUnit + FluentAssertions) unless the issue says
+5. Add or update tests in `Pulse.Tests` (xUnit + AwesomeAssertions) unless the issue says
    otherwise.
 6. Run `dotnet build -c Release` and `dotnet test -c Release` locally. Analyzer compliance
    (`HoneyDrunk.Standards`) is mandatory; warnings are errors.

--- a/HoneyDrunk.Pulse/CHANGELOG.md
+++ b/HoneyDrunk.Pulse/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+- Migrated Pulse tests to AwesomeAssertions, adopted HoneyDrunk.Standards.Tests 0.2.9, and refreshed HoneyDrunk.Standards to 0.2.9 across the solution for ADR-0047 testing alignment.
 - Seeded the Pulse coverage baseline and wired the push-to-main coverage baseline ratchet for the Grid PR coverage gate.
 
 ## [0.3.0] - 2026-05-18

--- a/HoneyDrunk.Pulse/HoneyDrunk.Pulse.Contracts/CHANGELOG.md
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Pulse.Contracts/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to HoneyDrunk.Pulse.Contracts will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Refreshed HoneyDrunk.Standards to 0.2.9 for ADR-0047 testing tooling alignment.
+
 ## [0.3.0] - 2026-05-18
 
 ### Changed

--- a/HoneyDrunk.Pulse/HoneyDrunk.Pulse.Contracts/HoneyDrunk.Pulse.Contracts.csproj
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Pulse.Contracts/HoneyDrunk.Pulse.Contracts.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/HoneyDrunk.Pulse/HoneyDrunk.Pulse.Sample.Api/HoneyDrunk.Pulse.Sample.Api.csproj
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Pulse.Sample.Api/HoneyDrunk.Pulse.Sample.Api.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/HoneyDrunk.Pulse/HoneyDrunk.Pulse.Sample.Worker/HoneyDrunk.Pulse.Sample.Worker.csproj
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Pulse.Sample.Worker/HoneyDrunk.Pulse.Sample.Worker.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Abstractions/CHANGELOG.md
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Abstractions/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to HoneyDrunk.Telemetry.Abstractions will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Refreshed HoneyDrunk.Standards to 0.2.9 for ADR-0047 testing tooling alignment.
+
 ## [0.3.0] - 2026-05-18
 
 ### Changed

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Abstractions/HoneyDrunk.Telemetry.Abstractions.csproj
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Abstractions/HoneyDrunk.Telemetry.Abstractions.csproj
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.7.0" />
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.OpenTelemetry/CHANGELOG.md
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.OpenTelemetry/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to HoneyDrunk.Telemetry.OpenTelemetry will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Refreshed HoneyDrunk.Standards to 0.2.9 for ADR-0047 testing tooling alignment.
+
 ## [0.3.0] - 2026-05-18
 
 ### Changed

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.OpenTelemetry/HoneyDrunk.Telemetry.OpenTelemetry.csproj
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.OpenTelemetry/HoneyDrunk.Telemetry.OpenTelemetry.csproj
@@ -42,7 +42,7 @@
 
   <ItemGroup>
     <PackageReference Include="HoneyDrunk.Kernel.Abstractions" Version="0.7.0" />
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.AzureMonitor/CHANGELOG.md
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.AzureMonitor/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to HoneyDrunk.Telemetry.Sink.AzureMonitor will be documented
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Refreshed HoneyDrunk.Standards to 0.2.9 for ADR-0047 testing tooling alignment.
+
 ## [0.3.0] - 2026-05-18
 
 ### Changed

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.AzureMonitor/HoneyDrunk.Telemetry.Sink.AzureMonitor.csproj
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.AzureMonitor/HoneyDrunk.Telemetry.Sink.AzureMonitor.csproj
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.7.0" />
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Loki/CHANGELOG.md
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Loki/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to HoneyDrunk.Telemetry.Sink.Loki will be documented in this
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Refreshed HoneyDrunk.Standards to 0.2.9 for ADR-0047 testing tooling alignment.
+
 ## [0.3.0] - 2026-05-18
 
 ### Changed

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Loki/HoneyDrunk.Telemetry.Sink.Loki.csproj
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Loki/HoneyDrunk.Telemetry.Sink.Loki.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Mimir/CHANGELOG.md
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Mimir/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to HoneyDrunk.Telemetry.Sink.Mimir will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Refreshed HoneyDrunk.Standards to 0.2.9 for ADR-0047 testing tooling alignment.
+
 ## [0.3.0] - 2026-05-18
 
 ### Changed

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Mimir/HoneyDrunk.Telemetry.Sink.Mimir.csproj
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Mimir/HoneyDrunk.Telemetry.Sink.Mimir.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.PostHog/CHANGELOG.md
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.PostHog/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to HoneyDrunk.Telemetry.Sink.PostHog will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Refreshed HoneyDrunk.Standards to 0.2.9 for ADR-0047 testing tooling alignment.
+
 ## [0.3.0] - 2026-05-18
 
 ### Changed

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.PostHog/HoneyDrunk.Telemetry.Sink.PostHog.csproj
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.PostHog/HoneyDrunk.Telemetry.Sink.PostHog.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Sentry/CHANGELOG.md
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Sentry/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to HoneyDrunk.Telemetry.Sink.Sentry will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Refreshed HoneyDrunk.Standards to 0.2.9 for ADR-0047 testing tooling alignment.
+
 ## [0.3.0] - 2026-05-18
 
 ### Changed

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Sentry/HoneyDrunk.Telemetry.Sink.Sentry.csproj
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Sentry/HoneyDrunk.Telemetry.Sink.Sentry.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Tempo/CHANGELOG.md
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Tempo/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to HoneyDrunk.Telemetry.Sink.Tempo will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Refreshed HoneyDrunk.Standards to 0.2.9 for ADR-0047 testing tooling alignment.
+
 ## [0.3.0] - 2026-05-18
 
 ### Changed

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Tempo/HoneyDrunk.Telemetry.Sink.Tempo.csproj
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Tempo/HoneyDrunk.Telemetry.Sink.Tempo.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/HoneyDrunk.Pulse/Pulse.Collector/HoneyDrunk.Pulse.Collector.csproj
+++ b/HoneyDrunk.Pulse/Pulse.Collector/HoneyDrunk.Pulse.Collector.csproj
@@ -17,7 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="HoneyDrunk.Kernel" Version="0.7.0" />
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/HoneyDrunk.Pulse/Pulse.Tests/Collector/CollectorSmokeTests.cs
+++ b/HoneyDrunk.Pulse/Pulse.Tests/Collector/CollectorSmokeTests.cs
@@ -2,7 +2,7 @@
 // Copyright (c) HoneyDrunk Studios. All rights reserved.
 // </copyright>
 
-using FluentAssertions;
+using AwesomeAssertions;
 using HoneyDrunk.Kernel.Abstractions;
 using HoneyDrunk.Kernel.Abstractions.Context;
 using Microsoft.Extensions.DependencyInjection;

--- a/HoneyDrunk.Pulse/Pulse.Tests/Collector/IngestionPipelineTests.cs
+++ b/HoneyDrunk.Pulse/Pulse.Tests/Collector/IngestionPipelineTests.cs
@@ -2,7 +2,7 @@
 // Copyright (c) HoneyDrunk Studios. All rights reserved.
 // </copyright>
 
-using FluentAssertions;
+using AwesomeAssertions;
 using HoneyDrunk.Kernel.Abstractions.Context;
 using HoneyDrunk.Pulse.Collector.Configuration;
 using HoneyDrunk.Pulse.Collector.Enrichment;

--- a/HoneyDrunk.Pulse/Pulse.Tests/Collector/OtlpEndpointValidationTests.cs
+++ b/HoneyDrunk.Pulse/Pulse.Tests/Collector/OtlpEndpointValidationTests.cs
@@ -2,7 +2,7 @@
 // Copyright (c) HoneyDrunk Studios. All rights reserved.
 // </copyright>
 
-using FluentAssertions;
+using AwesomeAssertions;
 using HoneyDrunk.Pulse.Collector.Configuration;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;

--- a/HoneyDrunk.Pulse/Pulse.Tests/Collector/OtlpParserTests.cs
+++ b/HoneyDrunk.Pulse/Pulse.Tests/Collector/OtlpParserTests.cs
@@ -2,7 +2,7 @@
 // Copyright (c) HoneyDrunk Studios. All rights reserved.
 // </copyright>
 
-using FluentAssertions;
+using AwesomeAssertions;
 using HoneyDrunk.Pulse.Collector.Ingestion;
 using Microsoft.Extensions.Logging.Abstractions;
 using System.Text;

--- a/HoneyDrunk.Pulse/Pulse.Tests/Collector/SinkFailureScenarioTests.cs
+++ b/HoneyDrunk.Pulse/Pulse.Tests/Collector/SinkFailureScenarioTests.cs
@@ -2,7 +2,7 @@
 // Copyright (c) HoneyDrunk Studios. All rights reserved.
 // </copyright>
 
-using FluentAssertions;
+using AwesomeAssertions;
 using HoneyDrunk.Kernel.Abstractions.Context;
 using HoneyDrunk.Pulse.Collector.Configuration;
 using HoneyDrunk.Pulse.Collector.Enrichment;

--- a/HoneyDrunk.Pulse/Pulse.Tests/Collector/TelemetryEnricherTests.cs
+++ b/HoneyDrunk.Pulse/Pulse.Tests/Collector/TelemetryEnricherTests.cs
@@ -2,7 +2,7 @@
 // Copyright (c) HoneyDrunk Studios. All rights reserved.
 // </copyright>
 
-using FluentAssertions;
+using AwesomeAssertions;
 using HoneyDrunk.Pulse.Collector.Configuration;
 using HoneyDrunk.Pulse.Collector.Enrichment;
 using HoneyDrunk.Telemetry.Abstractions.Tags;

--- a/HoneyDrunk.Pulse/Pulse.Tests/Collector/TransportValidationTests.cs
+++ b/HoneyDrunk.Pulse/Pulse.Tests/Collector/TransportValidationTests.cs
@@ -2,7 +2,7 @@
 // Copyright (c) HoneyDrunk Studios. All rights reserved.
 // </copyright>
 
-using FluentAssertions;
+using AwesomeAssertions;
 using HoneyDrunk.Pulse.Collector.Configuration;
 using Microsoft.AspNetCore.Builder;
 

--- a/HoneyDrunk.Pulse/Pulse.Tests/HoneyDrunk.Pulse.Tests.csproj
+++ b/HoneyDrunk.Pulse/Pulse.Tests/HoneyDrunk.Pulse.Tests.csproj
@@ -10,22 +10,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="8.9.0" />
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="HoneyDrunk.Standards.Tests" Version="0.2.9" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.6" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/HoneyDrunk.Pulse/Pulse.Tests/Telemetry/CoverageGateBackfillTests.cs
+++ b/HoneyDrunk.Pulse/Pulse.Tests/Telemetry/CoverageGateBackfillTests.cs
@@ -2,7 +2,7 @@
 // Copyright (c) HoneyDrunk Studios. All rights reserved.
 // </copyright>
 
-using FluentAssertions;
+using AwesomeAssertions;
 using Google.Protobuf;
 using HoneyDrunk.Pulse.Collector.Ingestion;
 using HoneyDrunk.Telemetry.Abstractions.Abstractions;

--- a/HoneyDrunk.Pulse/Pulse.Tests/Telemetry/HttpOtlpSinkExporterTests.cs
+++ b/HoneyDrunk.Pulse/Pulse.Tests/Telemetry/HttpOtlpSinkExporterTests.cs
@@ -2,7 +2,7 @@
 // Copyright (c) HoneyDrunk Studios. All rights reserved.
 // </copyright>
 
-using FluentAssertions;
+using AwesomeAssertions;
 using HoneyDrunk.Telemetry.Sink.Loki.Implementation;
 using HoneyDrunk.Telemetry.Sink.Loki.Options;
 using HoneyDrunk.Telemetry.Sink.Mimir.Implementation;

--- a/HoneyDrunk.Pulse/Pulse.Tests/Telemetry/PostHogMappingTests.cs
+++ b/HoneyDrunk.Pulse/Pulse.Tests/Telemetry/PostHogMappingTests.cs
@@ -2,7 +2,7 @@
 // Copyright (c) HoneyDrunk Studios. All rights reserved.
 // </copyright>
 
-using FluentAssertions;
+using AwesomeAssertions;
 using HoneyDrunk.Telemetry.Abstractions.Models;
 using HoneyDrunk.Telemetry.Abstractions.Tags;
 using HoneyDrunk.Telemetry.Sink.PostHog.Mapping;

--- a/HoneyDrunk.Pulse/Pulse.Tests/Telemetry/PostHogSinkTests.cs
+++ b/HoneyDrunk.Pulse/Pulse.Tests/Telemetry/PostHogSinkTests.cs
@@ -2,7 +2,7 @@
 // Copyright (c) HoneyDrunk Studios. All rights reserved.
 // </copyright>
 
-using FluentAssertions;
+using AwesomeAssertions;
 using HoneyDrunk.Telemetry.Abstractions.Models;
 using HoneyDrunk.Telemetry.Sink.PostHog.Implementation;
 using HoneyDrunk.Telemetry.Sink.PostHog.Options;

--- a/HoneyDrunk.Pulse/Pulse.Tests/Telemetry/SentrySinkTests.cs
+++ b/HoneyDrunk.Pulse/Pulse.Tests/Telemetry/SentrySinkTests.cs
@@ -2,7 +2,7 @@
 // Copyright (c) HoneyDrunk Studios. All rights reserved.
 // </copyright>
 
-using FluentAssertions;
+using AwesomeAssertions;
 using HoneyDrunk.Telemetry.Abstractions.Models;
 using HoneyDrunk.Telemetry.Sink.Sentry.Options;
 

--- a/HoneyDrunk.Pulse/Pulse.Tests/Telemetry/TelemetryEventTests.cs
+++ b/HoneyDrunk.Pulse/Pulse.Tests/Telemetry/TelemetryEventTests.cs
@@ -2,7 +2,7 @@
 // Copyright (c) HoneyDrunk Studios. All rights reserved.
 // </copyright>
 
-using FluentAssertions;
+using AwesomeAssertions;
 using HoneyDrunk.Telemetry.Abstractions.Models;
 
 namespace HoneyDrunk.Pulse.Tests.Telemetry;

--- a/HoneyDrunk.Pulse/Pulse.Tests/Transport/PulseIngestedPublishTests.cs
+++ b/HoneyDrunk.Pulse/Pulse.Tests/Transport/PulseIngestedPublishTests.cs
@@ -2,7 +2,7 @@
 // Copyright (c) HoneyDrunk Studios. All rights reserved.
 // </copyright>
 
-using FluentAssertions;
+using AwesomeAssertions;
 using HoneyDrunk.Pulse.Contracts;
 using HoneyDrunk.Pulse.Contracts.Events;
 

--- a/HoneyDrunk.Pulse/Pulse.Tests/Transport/TransportPublishingIntegrationTests.cs
+++ b/HoneyDrunk.Pulse/Pulse.Tests/Transport/TransportPublishingIntegrationTests.cs
@@ -2,7 +2,7 @@
 // Copyright (c) HoneyDrunk Studios. All rights reserved.
 // </copyright>
 
-using FluentAssertions;
+using AwesomeAssertions;
 using HoneyDrunk.Kernel.Abstractions.Context;
 using HoneyDrunk.Pulse.Contracts.Events;
 using HoneyDrunk.Pulse.Tests.Collector;


### PR DESCRIPTION
## Summary

- migrate Pulse tests and repo guidance from FluentAssertions to AwesomeAssertions
- adopt `HoneyDrunk.Standards.Tests` 0.2.9 in `Pulse.Tests` so the ADR-0047 test stack flows from the shared package
- refresh `HoneyDrunk.Standards` references to 0.2.9 across the Pulse solution and document the alignment in changelogs

## Validation

- `git diff --check`
- `dotnet restore HoneyDrunk.Pulse/HoneyDrunk.Pulse.slnx --source https://api.nuget.org/v3/index.json`
- `dotnet test HoneyDrunk.Pulse/HoneyDrunk.Pulse.slnx -c Release --no-restore`
  - `HoneyDrunk.Pulse.Tests`: 158 passed
  - Note: local Windows run emitted a coverlet file-lock warning while restoring instrumentation for `HoneyDrunk.Pulse.Collector.dll`; test exit code was 0. CI should be the source of truth for Linux coverage collection.

## ADR / Issues

Contributes to HoneyDrunk.Architecture#188.