### PR TITLE
ci: route weekly dependency issues through hive token

### DIFF
--- a/.github/workflows/weekly-deps.yml
+++ b/.github/workflows/weekly-deps.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   weekly-deps:
@@ -22,4 +23,4 @@ jobs:
       create-update-prs: true
       actions-ref: 'main'
     secrets:
-      github-token: ${{ secrets.GITHUB_TOKEN }}
+      github-token: ${{ secrets.HIVE_FIELD_MIRROR_TOKEN }}


### PR DESCRIPTION
## Summary

- grants issues: write to .github/workflows/weekly-deps.yml
- switches dependency issue maintenance from GITHUB_TOKEN to HIVE_FIELD_MIRROR_TOKEN
- aligns the weekly dependency caller with HoneyDrunk.Actions/.github/workflows/nightly-deps.yml@main, which maintains the 📦 Outdated Dependencies issue

## Why

The verified Transport run showed weekly dependency callers need issues: write because the reusable 
ightly-deps.yml workflow maintains dependency tracking issues.

It also showed that issues created with GITHUB_TOKEN do not trigger downstream issues:* workflows, so Hive Field Mirror will not add them to the Hive project. Using HIVE_FIELD_MIRROR_TOKEN keeps dependency tracking issues on the normal Hive project mirroring path.

## Validation

- git diff --check
- same weekly-deps permission fix verified first in HoneyDrunk.Transport: https://github.com/HoneyDrunkStudios/HoneyDrunk.Transport/actions/runs/26415087947
- after merge, manually dispatch $name Weekly Dependencies once to verify the dependency issue is created/updated and mirrored into Hive

Out-of-band reason: Follow-up rollout of the verified weekly dependency workflow startup and Hive mirroring fix; no generated packet exists for this operational correction.

Authorship: agent-codex
