### PR TITLE
ci: centralize release workflow mechanics

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,8 +33,8 @@ jobs:
             VERSION="${GITHUB_REF#refs/tags/v}"
             VERSION_TAG="${GITHUB_REF#refs/tags/}"
           fi
-          if [[ ! "$VERSION" =~ ^(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)(-((0|[1-9][0-9]*)|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)([.]((0|[1-9][0-9]*)|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?([+][0-9A-Za-z-]+([.][0-9A-Za-z-]+)*)?$ ]]; then
-            echo "::error::Version must be SemVer-compatible (for example 1.2.3, 1.2.3-preview.1, or 1.2.3-preview.1+build.5): $VERSION"
+          if [[ ! "$VERSION" =~ ^(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)(-((0|[1-9][0-9]*)|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)([.]((0|[1-9][0-9]*)|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?$ ]]; then
+            echo "::error::Version must be a NuGet package version without build metadata (for example 1.2.3 or 1.2.3-preview.1)."
             exit 1
           fi
           printf 'version=%s\n' "$VERSION" >>"$GITHUB_OUTPUT"
@@ -45,6 +45,7 @@ jobs:
   release:
     name: Build, Pack & Publish
     needs: prepare
+    # Reusable workflow permissions are the maximum allowed set; release.yml narrows permissions per internal job.
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,7 @@ jobs:
     name: Build, Pack & Publish
     needs: prepare
     permissions:
-      contents: read
+      contents: write
       packages: write
       id-token: write
       security-events: write
@@ -64,52 +64,22 @@ jobs:
       azure-client-id: ${{ vars.AZURE_CLIENT_ID }}
       azure-tenant-id: ${{ vars.AZURE_TENANT_ID }}
       azure-subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+      package-version: ${{ needs.prepare.outputs.version }}
+      create-github-release: true
+      github-release-tag: ${{ needs.prepare.outputs.version-tag }}
+      release-product-name: HoneyDrunk.Pulse
+      release-product-description: 'Unified observability platform for HoneyDrunk.OS -- telemetry collection, routing, and multi-sink export for .NET 10.'
+      release-nuget-packages: |
+        HoneyDrunk.Pulse.Contracts
+        HoneyDrunk.Telemetry.Abstractions
+        HoneyDrunk.Telemetry.OpenTelemetry
+        HoneyDrunk.Telemetry.Sink.AzureMonitor
+        HoneyDrunk.Telemetry.Sink.Loki
+        HoneyDrunk.Telemetry.Sink.Mimir
+        HoneyDrunk.Telemetry.Sink.PostHog
+        HoneyDrunk.Telemetry.Sink.Sentry
+        HoneyDrunk.Telemetry.Sink.Tempo
+      release-docs-url: 'https://github.com/HoneyDrunkStudios/HoneyDrunk.Pulse#readme'
       actions-ref: 'main'
     secrets:
       nuget-api-key: ${{ secrets.NUGET_API_KEY }}
-
-  github-release:
-    name: Create GitHub Release
-    needs: [prepare, release]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Checkout Actions
-        uses: actions/checkout@v5
-        with:
-          repository: HoneyDrunkStudios/HoneyDrunk.Actions
-          ref: main
-          path: .actions
-
-      - name: Generate Release Notes
-        id: notes
-        uses: ./.actions/.github/actions/release/generate-notes
-        with:
-          version: ${{ needs.prepare.outputs.version }}
-          product-name: HoneyDrunk.Pulse
-          product-description: 'Unified observability platform for HoneyDrunk.OS -- telemetry collection, routing, and multi-sink export for .NET 10.'
-          nuget-packages: |
-            HoneyDrunk.Pulse.Contracts
-            HoneyDrunk.Telemetry.Abstractions
-            HoneyDrunk.Telemetry.OpenTelemetry
-            HoneyDrunk.Telemetry.Sink.AzureMonitor
-            HoneyDrunk.Telemetry.Sink.Loki
-            HoneyDrunk.Telemetry.Sink.Mimir
-            HoneyDrunk.Telemetry.Sink.PostHog
-            HoneyDrunk.Telemetry.Sink.Sentry
-            HoneyDrunk.Telemetry.Sink.Tempo
-          docs-url: 'https://github.com/HoneyDrunkStudios/HoneyDrunk.Pulse#readme'
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: ${{ needs.prepare.outputs.version-tag }}
-          name: HoneyDrunk.Pulse ${{ needs.prepare.outputs.version-tag }}
-          body: ${{ steps.notes.outputs.body }}
-          generate_release_notes: ${{ steps.notes.outputs.has-changelog == 'false' }}
-          draft: false
-          prerelease: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,8 +33,12 @@ jobs:
             VERSION="${GITHUB_REF#refs/tags/v}"
             VERSION_TAG="${GITHUB_REF#refs/tags/}"
           fi
-          echo "version=$VERSION" >>"$GITHUB_OUTPUT"
-          echo "version_tag=$VERSION_TAG" >>"$GITHUB_OUTPUT"
+          if [[ ! "$VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+([-.+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Version must be SemVer-like (for example 1.2.3 or 1.2.3-preview.1): $VERSION"
+            exit 1
+          fi
+          printf 'version=%s\n' "$VERSION" >>"$GITHUB_OUTPUT"
+          printf 'version_tag=%s\n' "$VERSION_TAG" >>"$GITHUB_OUTPUT"
           echo "Publishing version: $VERSION"
           echo "Publishing tag: $VERSION_TAG"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,8 +33,8 @@ jobs:
             VERSION="${GITHUB_REF#refs/tags/v}"
             VERSION_TAG="${GITHUB_REF#refs/tags/}"
           fi
-          if [[ ! "$VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+([-.+][0-9A-Za-z.-]+)?$ ]]; then
-            echo "::error::Version must be SemVer-like (for example 1.2.3 or 1.2.3-preview.1): $VERSION"
+          if [[ ! "$VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z-]+([.][0-9A-Za-z-]+)*)?([+][0-9A-Za-z-]+([.][0-9A-Za-z-]+)*)?$ ]]; then
+            echo "::error::Version must be SemVer-compatible (for example 1.2.3, 1.2.3-preview.1, or 1.2.3-preview.1+build.5): $VERSION"
             exit 1
           fi
           printf 'version=%s\n' "$VERSION" >>"$GITHUB_OUTPUT"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.get_version.outputs.version }}
-      version-tag: ${{ steps.get_version.outputs.version-tag }}
+      version_tag: ${{ steps.get_version.outputs.version_tag }}
     steps:
       - name: Determine version
         id: get_version
@@ -36,7 +36,7 @@ jobs:
             VERSION_TAG="${GITHUB_REF#refs/tags/}"
           fi
           echo "version=$VERSION" >>"$GITHUB_OUTPUT"
-          echo "version-tag=$VERSION_TAG" >>"$GITHUB_OUTPUT"
+          echo "version_tag=$VERSION_TAG" >>"$GITHUB_OUTPUT"
           echo "Publishing version: $VERSION"
           echo "Publishing tag: $VERSION_TAG"
 
@@ -66,7 +66,7 @@ jobs:
       azure-subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
       package-version: ${{ needs.prepare.outputs.version }}
       create-github-release: true
-      github-release-tag: ${{ needs.prepare.outputs.version-tag }}
+      github-release-tag: ${{ needs.prepare.outputs.version_tag }}
       release-product-name: HoneyDrunk.Pulse
       release-product-description: 'Unified observability platform for HoneyDrunk.OS -- telemetry collection, routing, and multi-sink export for .NET 10.'
       release-nuget-packages: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
             VERSION="${GITHUB_REF#refs/tags/v}"
             VERSION_TAG="${GITHUB_REF#refs/tags/}"
           fi
-          if [[ ! "$VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z-]+([.][0-9A-Za-z-]+)*)?([+][0-9A-Za-z-]+([.][0-9A-Za-z-]+)*)?$ ]]; then
+          if [[ ! "$VERSION" =~ ^(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)(-((0|[1-9][0-9]*)|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)([.]((0|[1-9][0-9]*)|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?([+][0-9A-Za-z-]+([.][0-9A-Za-z-]+)*)?$ ]]; then
             echo "::error::Version must be SemVer-compatible (for example 1.2.3, 1.2.3-preview.1, or 1.2.3-preview.1+build.5): $VERSION"
             exit 1
           fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,9 +25,11 @@ jobs:
       - name: Determine version
         id: get_version
         shell: bash
+        env:
+          WORKFLOW_DISPATCH_VERSION: ${{ github.event.inputs.version }}
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            VERSION="${{ github.event.inputs.version }}"
+            VERSION="$WORKFLOW_DISPATCH_VERSION"
             VERSION_TAG="v${VERSION}"
           else
             VERSION="${GITHUB_REF#refs/tags/v}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,15 +11,13 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: write
-  packages: write
-  id-token: write
+permissions: {}
 
 jobs:
   prepare:
     name: Prepare Release
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       version: ${{ steps.get_version.outputs.version }}
       version_tag: ${{ steps.get_version.outputs.version_tag }}


### PR DESCRIPTION
## Summary
- Route GitHub Release creation through the centralized HoneyDrunk.Actions release workflow.
- Pass the prepared release version/tag and release-note metadata into the reusable workflow.
- Remove repo-local release-note and GitHub Release jobs that duplicated checkout/setup/release mechanics.
- Keep publish version output handling aligned with the cross-repo workflow standard.

## Testing
- Parsed `.github/workflows/*.yml` with PyYAML.
- `git diff --check`
- Verified no repo-local `actions/checkout`, `actions/setup-dotnet`, `actions/upload-artifact`, `softprops/action-gh-release`, unsafe publish output writes, or stale `version-tag` references remain in the standardized workflow paths.

## PR Metadata
Authorship: agent-codex
Packet: N/A
Out-of-band reason: Cross-repo workflow standardization requested after ADR-0012 Node 24 cleanup exposed release workflow drift.