### PR TITLE
ci(release): staged approval-gate promotion (ADR-0033 amendment)

### DIFF
--- a/.github/workflows/release-collector.yml
+++ b/.github/workflows/release-collector.yml
@@ -1,30 +1,112 @@
 name: Release Pulse.Collector
 
-# Tag-triggered release for Pulse.Collector.
-# Push a tag like `collector-v0.1.0` to build the container image, push it
-# to the shared ACR, and roll a new revision on ca-hd-pulse-<env> via the
-# reusable job-deploy-container-app.yml (ADR-0015 hosting, ADR-0012: deploy
-# logic lives in HoneyDrunk.Actions).
+# Dual-trigger release for Pulse.Collector (ADR-0033).
 #
-# Replaces the previous App Service slot-swap deploy.yml: Pulse.Collector is
-# gRPC, and ADR-0015 puts containerized Nodes on Azure Container Apps with
-# revision-based traffic shifting (not App Service slot swap).
+# Two trigger paths, mapped to a target environment in the `classify` job —
+# the single, explicit place trigger intent becomes an environment (D2):
+#
+#   * push to `main`, path-filtered to this deployable's source closure
+#     -> continuous deploy to `dev`. The image is tagged with the commit SHA;
+#     `dev` is disposable and never a promotion source (D1).
+#   * `collector-v*` SemVer tag, unfiltered (path filters are not evaluated
+#     for tag pushes) -> deliberate, versioned promotion. Tags resolve to
+#     `staging`; `prod` is reached via workflow_dispatch (D1). staging/prod
+#     are not provisioned yet; this records the model so it is not re-litigated.
+#   * workflow_dispatch -> manual escape hatch; pick the target environment.
+#
+# Deploy mechanics stay in HoneyDrunk.Actions (ADR-0012, ADR-0015); only
+# trigger policy — inherently per-repo — lives here. The path filter is scoped
+# to Pulse.Collector's transitive closure: its own source plus Contracts, the
+# Telemetry abstractions/pipeline, and every telemetry sink. The Sink.* glob
+# covers all concrete sinks and the shared-source Sink.Shared, so a newly-added
+# sink is auto-covered without editing this filter (D3).
 
 on:
   push:
+    branches: [main]
+    paths:
+      # Own deployable source (Dockerfile and .proto files live here).
+      - 'HoneyDrunk.Pulse/Pulse.Collector/**'
+      # ProjectReference closure of the Collector binary. The Sink.* glob
+      # covers all six concrete sinks AND the shared-source Sink.Shared
+      # (compiled into Loki/Mimir/Tempo via <Compile Include>), so a new sink
+      # is auto-covered without editing this filter.
+      - 'HoneyDrunk.Pulse/HoneyDrunk.Pulse.Contracts/**'
+      - 'HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Abstractions/**'
+      - 'HoneyDrunk.Pulse/HoneyDrunk.Telemetry.OpenTelemetry/**'
+      - 'HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.*/**'
+      # Solution file and the workflow itself.
+      - 'HoneyDrunk.Pulse/HoneyDrunk.Pulse.slnx'
+      - '.github/workflows/release-collector.yml'
     tags:
       - 'collector-v*'
   workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Target environment for a manual deploy'
+        type: choice
+        options:
+          - dev
+          - staging
+          - prod
+        default: dev
 
 permissions:
   contents: read
   id-token: write
 
 jobs:
-  resolve:
-    name: Resolve dev config
+  classify:
+    name: Classify trigger
     runs-on: ubuntu-latest
-    environment: dev
+    # ADR-0033 D2: the single, explicit place trigger intent is mapped to a
+    # target environment. resolve/deploy consume these outputs; the environment
+    # is never inferred implicitly from vars.HD_ENV or scattered across jobs.
+    outputs:
+      target-env: ${{ steps.map.outputs.target-env }}
+      image-tag: ${{ steps.map.outputs.image-tag }}
+    steps:
+      - name: Map trigger to environment
+        id: map
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF: ${{ github.ref }}
+          REF_NAME: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
+          DISPATCH_ENV: ${{ inputs.environment }}
+        run: |
+          set -euo pipefail
+          #   push:main (path-filtered) -> dev      (continuous, SHA-identified)
+          #   push:tag  (collector-v*)  -> staging  (promotion; prod via dispatch)
+          #   workflow_dispatch         -> chosen environment input
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TARGET="$DISPATCH_ENV"
+          elif [[ "$REF" == refs/tags/* ]]; then
+            TARGET="staging"
+          else
+            TARGET="dev"
+          fi
+          case "$TARGET" in
+            dev|staging|prod) ;;
+            *) echo "::error::Unrecognized target environment '$TARGET'"; exit 1 ;;
+          esac
+          # ADR-0033 D1: dev images are SHA-identified (no version stamp);
+          # promotion tags carry the SemVer-shaped ref as the image tag.
+          if [[ "$REF" == refs/tags/* ]]; then
+            IMAGE_TAG="$REF_NAME"
+          else
+            IMAGE_TAG="$SHA"
+          fi
+          echo "target-env=$TARGET" >> "$GITHUB_OUTPUT"
+          echo "image-tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          echo "Resolved target environment: $TARGET (image tag: $IMAGE_TAG)"
+
+  resolve:
+    name: Resolve ${{ needs.classify.outputs.target-env }} config
+    needs: classify
+    runs-on: ubuntu-latest
+    environment: ${{ needs.classify.outputs.target-env }}
     # Output names use underscores (not hyphens). Dot-notation access
     # (needs.resolve.outputs.acr_registry) is unambiguous this way — avoids
     # any reader/linter doubt about hyphenated context keys.
@@ -39,28 +121,35 @@ jobs:
     steps:
       - name: Echo resolved targets
         run: |
+          echo "Environment   : ${{ needs.classify.outputs.target-env }}"
           echo "Container App : ca-hd-pulse-${{ vars.HD_ENV }}"
           echo "Resource Grp  : rg-hd-pulse-${{ vars.HD_ENV }}"
           echo "ACR           : acrhdshared${{ vars.HD_ENV }}.azurecr.io"
           echo "Key Vault     : kv-hd-pulse-${{ vars.HD_ENV }}"
 
   deploy:
-    name: Deploy to dev
-    needs: resolve
+    name: Deploy to ${{ needs.classify.outputs.target-env }}
+    needs: [classify, resolve]
+    # ADR-0033 D5: concurrency group keyed on the resolved environment, so dev
+    # churn can never cancel a staging/prod promotion (they land in different
+    # groups). Dev supersedes in-flight dev deploys (cancel-in-progress: true);
+    # promotions queue and are never silently cancelled (false).
+    concurrency:
+      group: release-collector-${{ needs.classify.outputs.target-env }}
+      cancel-in-progress: ${{ needs.classify.outputs.target-env == 'dev' }}
     # A reusable-workflow caller job cannot declare `environment:` itself, so
     # the environment is passed through as an input. The reusable workflow's
-    # deploy job runs under `environment: dev`, making the OIDC token subject
-    # repo:HoneyDrunkStudios/HoneyDrunk.Pulse:environment:dev — which matches
-    # the environment-scoped federated credential on sp-hd-pulse-dev.
-    # `resolve` (also environment: dev) separately supplies env-scoped vars.
+    # deploy job runs under that environment, making the OIDC token subject
+    # repo:HoneyDrunkStudios/HoneyDrunk.Pulse:environment:<env> — which matches
+    # the environment-scoped federated credential on sp-hd-pulse-<env>.
     uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-deploy-container-app.yml@main
     with:
-      environment: dev
+      environment: ${{ needs.classify.outputs.target-env }}
       # Dockerfile declares "Build context: HoneyDrunk.Pulse/ (solution root)".
       build-context: HoneyDrunk.Pulse
       dockerfile: Pulse.Collector/Dockerfile
       image-name: honeydrunk-pulse-collector
-      image-tag: ${{ github.ref_name }}
+      image-tag: ${{ needs.classify.outputs.image-tag }}
       # Left-side keys are reusable-workflow input names (stay hyphenated);
       # right-side are this workflow's resolve outputs (underscored).
       acr-registry: ${{ needs.resolve.outputs.acr_registry }}

--- a/.github/workflows/release-collector.yml
+++ b/.github/workflows/release-collector.yml
@@ -1,25 +1,29 @@
 name: Release Pulse.Collector
 
-# Dual-trigger release for Pulse.Collector (ADR-0033).
+# Staged release for Pulse.Collector (ADR-0033, staged-promotion amendment).
 #
-# Two trigger paths, mapped to a target environment in the `classify` job —
-# the single, explicit place trigger intent becomes an environment (D2):
+# Three deploy paths, each its own job under a static GitHub Environment:
 #
-#   * push to `main`, path-filtered to this deployable's source closure
-#     -> continuous deploy to `dev`. The image is tagged with the commit SHA;
-#     `dev` is disposable and never a promotion source (D1).
-#   * `collector-v*` SemVer tag, unfiltered (path filters are not evaluated
-#     for tag pushes) -> deliberate, versioned promotion. Tags resolve to
-#     `staging`; `prod` is reached via workflow_dispatch (D1). staging/prod
-#     are not provisioned yet; this records the model so it is not re-litigated.
-#   * workflow_dispatch -> manual escape hatch; pick the target environment.
+#   * push to `main`, path-filtered  -> deploy-dev (continuous; image dev-<sha>)
+#   * `collector-v*` SemVer tag      -> deploy-staging, then deploy-prod
+#   * workflow_dispatch              -> deploy-dev (manual escape hatch)
+#
+# Staged promotion (ADO-style): a tag push deploys to staging automatically,
+# then deploy-prod (needs: deploy-staging) is gated by the `prod` GitHub
+# Environment's required-reviewers rule — it queues after staging succeeds and
+# PAUSES until a human approves, then rolls prod. The gate is configured on the
+# prod Environment in repo settings (not in YAML) when prod is provisioned;
+# until then the staging/prod jobs only run on a tag and fail fast if the
+# environment's vars are unset.
+#
+# Image promotion: staging and prod each build the SemVer-tagged image from the
+# tagged source into their own per-env registry (acrhdshared<env>). Literal
+# build-once same-artifact promotion is deferred pending a registry-topology
+# decision (shared cross-env registry or `az acr import`) — see PR discussion.
 #
 # Deploy mechanics stay in HoneyDrunk.Actions (ADR-0012, ADR-0015); only
-# trigger policy — inherently per-repo — lives here. The path filter is scoped
-# to Pulse.Collector's transitive closure: its own source plus Contracts, the
-# Telemetry abstractions/pipeline, and every telemetry sink. The Sink.* glob
-# covers all concrete sinks and the shared-source Sink.Shared, so a newly-added
-# sink is auto-covered without editing this filter (D3).
+# trigger/stage policy — inherently per-repo — lives here. Path filters are not
+# evaluated for tag pushes, so the tag trigger stays unfiltered.
 #
 # Replaces the previous App Service slot-swap deploy.yml: Pulse.Collector is
 # gRPC, and ADR-0015 puts containerized Nodes on Azure Container Apps with
@@ -47,78 +51,21 @@ on:
     tags:
       - 'collector-v*'
   workflow_dispatch:
-    inputs:
-      environment:
-        description: 'Target environment for a manual deploy'
-        type: choice
-        options:
-          - dev
-          - staging
-          - prod
-        default: dev
 
-# id-token: write is granted per-job (deploy only) for least privilege; the
-# workflow default stays read-only.
+# id-token: write is granted per deploy job (least privilege); the workflow
+# default stays read-only.
 permissions:
   contents: read
 
 jobs:
-  classify:
-    name: Classify trigger
+  # ============================ DEV (continuous) ============================
+  resolve-dev:
+    name: Resolve dev config
+    # Branch push to main, or a manual dispatch. Tag pushes skip the dev path.
+    if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
-    # ADR-0033 D2: the single, explicit place trigger intent is mapped to a
-    # target environment. resolve/deploy consume these outputs; the environment
-    # is never inferred implicitly from vars.HD_ENV or scattered across jobs.
+    environment: dev
     # Output names use underscores (repo convention) for unambiguous dot-access.
-    outputs:
-      target_env: ${{ steps.map.outputs.target_env }}
-      image_tag: ${{ steps.map.outputs.image_tag }}
-    steps:
-      - name: Map trigger to environment
-        id: map
-        shell: bash
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          REF: ${{ github.ref }}
-          REF_NAME: ${{ github.ref_name }}
-          SHA: ${{ github.sha }}
-          DISPATCH_ENV: ${{ inputs.environment }}
-        run: |
-          set -euo pipefail
-          #   push:main (path-filtered) -> dev      (continuous, SHA-identified)
-          #   push:tag  (collector-v*)  -> staging  (promotion; prod via dispatch)
-          #   workflow_dispatch         -> chosen environment input
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            TARGET="$DISPATCH_ENV"
-          elif [[ "$REF" == refs/tags/* ]]; then
-            TARGET="staging"
-          else
-            TARGET="dev"
-          fi
-          case "$TARGET" in
-            dev|staging|prod) ;;
-            *) echo "::error::Unrecognized target environment '$TARGET'"; exit 1 ;;
-          esac
-          # ADR-0033 D1: dev images are SHA-identified (no version stamp), tagged
-          # dev-<sha> so ACR artifacts stay distinguishable as dev builds;
-          # promotion tags carry the SemVer-shaped ref as the image tag.
-          if [[ "$REF" == refs/tags/* ]]; then
-            IMAGE_TAG="$REF_NAME"
-          else
-            IMAGE_TAG="dev-$SHA"
-          fi
-          echo "target_env=$TARGET" >> "$GITHUB_OUTPUT"
-          echo "image_tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
-          echo "Resolved target environment: $TARGET (image tag: $IMAGE_TAG)"
-
-  resolve:
-    name: Resolve ${{ needs.classify.outputs.target_env }} config
-    needs: classify
-    runs-on: ubuntu-latest
-    environment: ${{ needs.classify.outputs.target_env }}
-    # Output names use underscores (not hyphens). Dot-notation access
-    # (needs.resolve.outputs.acr_registry) is unambiguous this way — avoids
-    # any reader/linter doubt about hyphenated context keys.
     outputs:
       acr_registry: acrhdshared${{ vars.HD_ENV }}.azurecr.io
       container_app: ca-hd-pulse-${{ vars.HD_ENV }}
@@ -128,54 +75,164 @@ jobs:
       azure_tenant_id: ${{ vars.AZURE_TENANT_ID }}
       azure_subscription_id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
     steps:
-      - name: Echo resolved targets
+      - name: Validate environment vars
+        env:
+          HD_ENV: ${{ vars.HD_ENV }}
         run: |
-          echo "Environment   : ${{ needs.classify.outputs.target_env }}"
-          echo "Container App : ca-hd-pulse-${{ vars.HD_ENV }}"
-          echo "Resource Grp  : rg-hd-pulse-${{ vars.HD_ENV }}"
-          echo "ACR           : acrhdshared${{ vars.HD_ENV }}.azurecr.io"
-          echo "Key Vault     : kv-hd-pulse-${{ vars.HD_ENV }}"
+          set -euo pipefail
+          if [ -z "$HD_ENV" ]; then
+            echo "::error::vars.HD_ENV is empty for environment 'dev' — is it provisioned/configured?"
+            exit 1
+          fi
+          echo "Environment   : dev"
+          echo "Container App : ca-hd-pulse-$HD_ENV"
+          echo "ACR           : acrhdshared$HD_ENV.azurecr.io"
 
-  deploy:
-    name: Deploy to ${{ needs.classify.outputs.target_env }}
-    needs: [classify, resolve]
-    # Only this job authenticates to Azure via OIDC, so id-token lives here.
+  deploy-dev:
+    name: Deploy to dev
+    needs: resolve-dev
     permissions:
       contents: read
       id-token: write
-    # ADR-0033 D5: concurrency group keyed on the resolved environment, so dev
-    # churn can never cancel a staging/prod promotion (they land in different
-    # groups). Dev supersedes in-flight dev deploys (cancel-in-progress: true);
-    # promotions queue and are never silently cancelled (false).
+    # Latest main supersedes in-flight dev deploys.
     concurrency:
-      group: release-collector-${{ needs.classify.outputs.target_env }}
-      cancel-in-progress: ${{ needs.classify.outputs.target_env == 'dev' }}
-    # A reusable-workflow caller job cannot declare `environment:` itself, so
-    # the environment is passed through as an input. The reusable workflow's
-    # deploy job runs under that environment, making the OIDC token subject
-    # repo:HoneyDrunkStudios/HoneyDrunk.Pulse:environment:<env> — which matches
-    # the environment-scoped federated credential on sp-hd-pulse-<env>.
+      group: release-collector-dev
+      cancel-in-progress: true
     uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-deploy-container-app.yml@main
     with:
-      environment: ${{ needs.classify.outputs.target_env }}
-      # Dockerfile declares "Build context: HoneyDrunk.Pulse/ (solution root)".
+      environment: dev
       build-context: HoneyDrunk.Pulse
       dockerfile: Pulse.Collector/Dockerfile
       image-name: honeydrunk-pulse-collector
-      image-tag: ${{ needs.classify.outputs.image_tag }}
-      # Left-side keys are reusable-workflow input names (stay hyphenated);
-      # right-side are this workflow's resolve outputs (underscored).
-      acr-registry: ${{ needs.resolve.outputs.acr_registry }}
-      container-app: ${{ needs.resolve.outputs.container_app }}
-      resource-group: ${{ needs.resolve.outputs.resource_group }}
-      azure-client-id: ${{ needs.resolve.outputs.azure_client_id }}
-      azure-tenant-id: ${{ needs.resolve.outputs.azure_tenant_id }}
-      azure-subscription-id: ${{ needs.resolve.outputs.azure_subscription_id }}
-      keyvault-name: ${{ needs.resolve.outputs.keyvault_name }}
+      # Dev images are SHA-identified (no version stamp), tagged dev-<sha>.
+      image-tag: dev-${{ github.sha }}
+      acr-registry: ${{ needs.resolve-dev.outputs.acr_registry }}
+      container-app: ${{ needs.resolve-dev.outputs.container_app }}
+      resource-group: ${{ needs.resolve-dev.outputs.resource_group }}
+      azure-client-id: ${{ needs.resolve-dev.outputs.azure_client_id }}
+      azure-tenant-id: ${{ needs.resolve-dev.outputs.azure_tenant_id }}
+      azure-subscription-id: ${{ needs.resolve-dev.outputs.azure_subscription_id }}
+      keyvault-name: ${{ needs.resolve-dev.outputs.keyvault_name }}
       keyvault-secrets: |
         PostHog--ApiKey
         Sentry--Dsn
-      # /health, /health/ready, /health/live already exist in Pulse.Collector
-      # (Endpoints/HealthEndpoints.cs) — unlike the Notify deployables.
+      health-check-url: /health
+      traffic-shift-mode: full
+
+  # ============================ STAGING (tag) ==============================
+  resolve-staging:
+    name: Resolve staging config
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-latest
+    environment: staging
+    outputs:
+      acr_registry: acrhdshared${{ vars.HD_ENV }}.azurecr.io
+      container_app: ca-hd-pulse-${{ vars.HD_ENV }}
+      resource_group: rg-hd-pulse-${{ vars.HD_ENV }}
+      keyvault_name: kv-hd-pulse-${{ vars.HD_ENV }}
+      azure_client_id: ${{ vars.AZURE_CLIENT_ID }}
+      azure_tenant_id: ${{ vars.AZURE_TENANT_ID }}
+      azure_subscription_id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+    steps:
+      - name: Validate environment vars
+        env:
+          HD_ENV: ${{ vars.HD_ENV }}
+        run: |
+          set -euo pipefail
+          if [ -z "$HD_ENV" ]; then
+            echo "::error::vars.HD_ENV is empty for environment 'staging' — not provisioned yet?"
+            exit 1
+          fi
+          echo "Environment   : staging"
+          echo "Container App : ca-hd-pulse-$HD_ENV"
+
+  deploy-staging:
+    name: Deploy to staging
+    needs: resolve-staging
+    permissions:
+      contents: read
+      id-token: write
+    # Promotions queue; never cancel a versioned promotion.
+    concurrency:
+      group: release-collector-staging
+      cancel-in-progress: false
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-deploy-container-app.yml@main
+    with:
+      environment: staging
+      build-context: HoneyDrunk.Pulse
+      dockerfile: Pulse.Collector/Dockerfile
+      image-name: honeydrunk-pulse-collector
+      # SemVer tag is the version-of-record; the image carries it verbatim.
+      image-tag: ${{ github.ref_name }}
+      acr-registry: ${{ needs.resolve-staging.outputs.acr_registry }}
+      container-app: ${{ needs.resolve-staging.outputs.container_app }}
+      resource-group: ${{ needs.resolve-staging.outputs.resource_group }}
+      azure-client-id: ${{ needs.resolve-staging.outputs.azure_client_id }}
+      azure-tenant-id: ${{ needs.resolve-staging.outputs.azure_tenant_id }}
+      azure-subscription-id: ${{ needs.resolve-staging.outputs.azure_subscription_id }}
+      keyvault-name: ${{ needs.resolve-staging.outputs.keyvault_name }}
+      keyvault-secrets: |
+        PostHog--ApiKey
+        Sentry--Dsn
+      health-check-url: /health
+      traffic-shift-mode: full
+
+  # ======================= PROD (gated; needs staging) =====================
+  resolve-prod:
+    name: Resolve prod config
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-latest
+    environment: prod
+    outputs:
+      acr_registry: acrhdshared${{ vars.HD_ENV }}.azurecr.io
+      container_app: ca-hd-pulse-${{ vars.HD_ENV }}
+      resource_group: rg-hd-pulse-${{ vars.HD_ENV }}
+      keyvault_name: kv-hd-pulse-${{ vars.HD_ENV }}
+      azure_client_id: ${{ vars.AZURE_CLIENT_ID }}
+      azure_tenant_id: ${{ vars.AZURE_TENANT_ID }}
+      azure_subscription_id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+    steps:
+      - name: Validate environment vars
+        env:
+          HD_ENV: ${{ vars.HD_ENV }}
+        run: |
+          set -euo pipefail
+          if [ -z "$HD_ENV" ]; then
+            echo "::error::vars.HD_ENV is empty for environment 'prod' — not provisioned yet?"
+            exit 1
+          fi
+          echo "Environment   : prod"
+          echo "Container App : ca-hd-pulse-$HD_ENV"
+
+  deploy-prod:
+    name: Deploy to prod
+    # The staged gate: prod runs only after staging succeeds, and the reusable
+    # workflow's inner deploy job runs under `environment: prod` — whose
+    # required-reviewers rule PAUSES the run until a human approves. Same
+    # SemVer tag rebuilt into the prod registry (see header note on same-artifact).
+    needs: [resolve-prod, resolve-staging, deploy-staging]
+    permissions:
+      contents: read
+      id-token: write
+    concurrency:
+      group: release-collector-prod
+      cancel-in-progress: false
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-deploy-container-app.yml@main
+    with:
+      environment: prod
+      build-context: HoneyDrunk.Pulse
+      dockerfile: Pulse.Collector/Dockerfile
+      image-name: honeydrunk-pulse-collector
+      image-tag: ${{ github.ref_name }}
+      acr-registry: ${{ needs.resolve-prod.outputs.acr_registry }}
+      container-app: ${{ needs.resolve-prod.outputs.container_app }}
+      resource-group: ${{ needs.resolve-prod.outputs.resource_group }}
+      azure-client-id: ${{ needs.resolve-prod.outputs.azure_client_id }}
+      azure-tenant-id: ${{ needs.resolve-prod.outputs.azure_tenant_id }}
+      azure-subscription-id: ${{ needs.resolve-prod.outputs.azure_subscription_id }}
+      keyvault-name: ${{ needs.resolve-prod.outputs.keyvault_name }}
+      keyvault-secrets: |
+        PostHog--ApiKey
+        Sentry--Dsn
       health-check-url: /health
       traffic-shift-mode: full

--- a/.github/workflows/release-collector.yml
+++ b/.github/workflows/release-collector.yml
@@ -20,6 +20,10 @@ name: Release Pulse.Collector
 # Telemetry abstractions/pipeline, and every telemetry sink. The Sink.* glob
 # covers all concrete sinks and the shared-source Sink.Shared, so a newly-added
 # sink is auto-covered without editing this filter (D3).
+#
+# Replaces the previous App Service slot-swap deploy.yml: Pulse.Collector is
+# gRPC, and ADR-0015 puts containerized Nodes on Azure Container Apps with
+# revision-based traffic shifting (not App Service slot swap).
 
 on:
   push:
@@ -35,8 +39,10 @@ on:
       - 'HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Abstractions/**'
       - 'HoneyDrunk.Pulse/HoneyDrunk.Telemetry.OpenTelemetry/**'
       - 'HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.*/**'
-      # Solution file and the workflow itself.
+      # Solution file, Docker ignore rules, and the workflow itself — all affect
+      # the built image. (No NuGet.config in this repo.)
       - 'HoneyDrunk.Pulse/HoneyDrunk.Pulse.slnx'
+      - 'HoneyDrunk.Pulse/.dockerignore'
       - '.github/workflows/release-collector.yml'
     tags:
       - 'collector-v*'
@@ -51,9 +57,10 @@ on:
           - prod
         default: dev
 
+# id-token: write is granted per-job (deploy only) for least privilege; the
+# workflow default stays read-only.
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   classify:
@@ -62,9 +69,10 @@ jobs:
     # ADR-0033 D2: the single, explicit place trigger intent is mapped to a
     # target environment. resolve/deploy consume these outputs; the environment
     # is never inferred implicitly from vars.HD_ENV or scattered across jobs.
+    # Output names use underscores (repo convention) for unambiguous dot-access.
     outputs:
-      target-env: ${{ steps.map.outputs.target-env }}
-      image-tag: ${{ steps.map.outputs.image-tag }}
+      target_env: ${{ steps.map.outputs.target_env }}
+      image_tag: ${{ steps.map.outputs.image_tag }}
     steps:
       - name: Map trigger to environment
         id: map
@@ -91,22 +99,23 @@ jobs:
             dev|staging|prod) ;;
             *) echo "::error::Unrecognized target environment '$TARGET'"; exit 1 ;;
           esac
-          # ADR-0033 D1: dev images are SHA-identified (no version stamp);
+          # ADR-0033 D1: dev images are SHA-identified (no version stamp), tagged
+          # dev-<sha> so ACR artifacts stay distinguishable as dev builds;
           # promotion tags carry the SemVer-shaped ref as the image tag.
           if [[ "$REF" == refs/tags/* ]]; then
             IMAGE_TAG="$REF_NAME"
           else
-            IMAGE_TAG="$SHA"
+            IMAGE_TAG="dev-$SHA"
           fi
-          echo "target-env=$TARGET" >> "$GITHUB_OUTPUT"
-          echo "image-tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          echo "target_env=$TARGET" >> "$GITHUB_OUTPUT"
+          echo "image_tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
           echo "Resolved target environment: $TARGET (image tag: $IMAGE_TAG)"
 
   resolve:
-    name: Resolve ${{ needs.classify.outputs.target-env }} config
+    name: Resolve ${{ needs.classify.outputs.target_env }} config
     needs: classify
     runs-on: ubuntu-latest
-    environment: ${{ needs.classify.outputs.target-env }}
+    environment: ${{ needs.classify.outputs.target_env }}
     # Output names use underscores (not hyphens). Dot-notation access
     # (needs.resolve.outputs.acr_registry) is unambiguous this way — avoids
     # any reader/linter doubt about hyphenated context keys.
@@ -121,22 +130,26 @@ jobs:
     steps:
       - name: Echo resolved targets
         run: |
-          echo "Environment   : ${{ needs.classify.outputs.target-env }}"
+          echo "Environment   : ${{ needs.classify.outputs.target_env }}"
           echo "Container App : ca-hd-pulse-${{ vars.HD_ENV }}"
           echo "Resource Grp  : rg-hd-pulse-${{ vars.HD_ENV }}"
           echo "ACR           : acrhdshared${{ vars.HD_ENV }}.azurecr.io"
           echo "Key Vault     : kv-hd-pulse-${{ vars.HD_ENV }}"
 
   deploy:
-    name: Deploy to ${{ needs.classify.outputs.target-env }}
+    name: Deploy to ${{ needs.classify.outputs.target_env }}
     needs: [classify, resolve]
+    # Only this job authenticates to Azure via OIDC, so id-token lives here.
+    permissions:
+      contents: read
+      id-token: write
     # ADR-0033 D5: concurrency group keyed on the resolved environment, so dev
     # churn can never cancel a staging/prod promotion (they land in different
     # groups). Dev supersedes in-flight dev deploys (cancel-in-progress: true);
     # promotions queue and are never silently cancelled (false).
     concurrency:
-      group: release-collector-${{ needs.classify.outputs.target-env }}
-      cancel-in-progress: ${{ needs.classify.outputs.target-env == 'dev' }}
+      group: release-collector-${{ needs.classify.outputs.target_env }}
+      cancel-in-progress: ${{ needs.classify.outputs.target_env == 'dev' }}
     # A reusable-workflow caller job cannot declare `environment:` itself, so
     # the environment is passed through as an input. The reusable workflow's
     # deploy job runs under that environment, making the OIDC token subject
@@ -144,12 +157,12 @@ jobs:
     # the environment-scoped federated credential on sp-hd-pulse-<env>.
     uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-deploy-container-app.yml@main
     with:
-      environment: ${{ needs.classify.outputs.target-env }}
+      environment: ${{ needs.classify.outputs.target_env }}
       # Dockerfile declares "Build context: HoneyDrunk.Pulse/ (solution root)".
       build-context: HoneyDrunk.Pulse
       dockerfile: Pulse.Collector/Dockerfile
       image-name: honeydrunk-pulse-collector
-      image-tag: ${{ needs.classify.outputs.image-tag }}
+      image-tag: ${{ needs.classify.outputs.image_tag }}
       # Left-side keys are reusable-workflow input names (stay hyphenated);
       # right-side are this workflow's resolve outputs (underscored).
       acr-registry: ${{ needs.resolve.outputs.acr_registry }}

--- a/.github/workflows/release-collector.yml
+++ b/.github/workflows/release-collector.yml
@@ -180,6 +180,12 @@ jobs:
   # ======================= PROD (gated; needs staging) =====================
   resolve-prod:
     name: Resolve prod config
+    # needs: deploy-staging so the prod Environment gate (required reviewers)
+    # can't be reached until staging succeeds — the approval pause happens AFTER
+    # staging, not in parallel with it. (Both resolve-prod and the deploy enter
+    # the prod environment; collapsing to a single approval is a prod-provisioning
+    # follow-up.)
+    needs: deploy-staging
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
     environment: prod
@@ -210,7 +216,7 @@ jobs:
     # workflow's inner deploy job runs under `environment: prod` — whose
     # required-reviewers rule PAUSES the run until a human approves. Same
     # SemVer tag rebuilt into the prod registry (see header note on same-artifact).
-    needs: [resolve-prod, resolve-staging, deploy-staging]
+    needs: [resolve-prod]
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary
Restructure `release-collector.yml` to an **ADO-style staged approval-gate promotion** model. Supersedes the earlier dual-trigger/`classify` shape on this branch.

## Model
Per-environment deploy jobs, each under a static GitHub Environment:

```
push → main / workflow_dispatch   →  deploy-dev          (continuous, dev-<sha>)
collector-v* tag                  →  deploy-staging  →  deploy-prod (GATED)
```

- **The gate** = the `prod` GitHub Environment's **required-reviewers** rule. `deploy-prod` `needs: deploy-staging` and the reusable workflow's inner job runs under `environment: prod`, so the run **pauses after staging until a human approves**, then rolls prod. Armed by configuring the prod Environment in repo settings when prod is provisioned.
- Each env has its own `resolve-<env>` job with a **fail-fast guard** if `HD_ENV` is unset.
- `id-token: write` scoped per deploy job; workflow default read-only.
- Staging and prod rebuild the SemVer-tagged image into each per-env registry (`acrhdshared<env>`). Build-once same-artifact promotion is deferred pending a registry-topology decision (shared registry or `az acr import`).

## Path-filter closure
Collector source · Contracts · Telemetry.Abstractions · Telemetry.OpenTelemetry · `Telemetry.Sink.*` (incl. shared-source `Sink.Shared`) · `.slnx` · `.dockerignore` · workflow.

## Review items addressed
`dev-<sha>` tags · `.dockerignore` in filter · underscored classify→resolve outputs (repo convention) · `id-token` least-privilege · empty-`HD_ENV` fail-fast · slot-swap paragraph retained · SHA-pin rejected (operator convention).

> **Amends ADR-0033 (D1/D6).** ADR amendment + packet rewrite to follow — the Grid Review will keep requesting changes against the current packet until those land.

Closes #18

Authorship: agent-claude-code
Packet: HoneyDrunkStudios/HoneyDrunk.Architecture:generated/issue-packets/active/adr-0033-deploy-trigger-model/03-pulse-collector-deploy-trigger-model.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
