### PR TITLE
chore(collector): adopt Vault 0.8.0 AddAppConfiguration overload

### DIFF
--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Loki/HoneyDrunk.Telemetry.Sink.Loki.csproj
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Loki/HoneyDrunk.Telemetry.Sink.Loki.csproj
@@ -34,7 +34,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="HoneyDrunk.Vault" Version="0.7.0" />
+    <PackageReference Include="HoneyDrunk.Vault" Version="0.8.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Mimir/HoneyDrunk.Telemetry.Sink.Mimir.csproj
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Mimir/HoneyDrunk.Telemetry.Sink.Mimir.csproj
@@ -34,7 +34,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="HoneyDrunk.Vault" Version="0.7.0" />
+    <PackageReference Include="HoneyDrunk.Vault" Version="0.8.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.PostHog/HoneyDrunk.Telemetry.Sink.PostHog.csproj
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.PostHog/HoneyDrunk.Telemetry.Sink.PostHog.csproj
@@ -34,7 +34,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="HoneyDrunk.Vault" Version="0.7.0" />
+    <PackageReference Include="HoneyDrunk.Vault" Version="0.8.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Sentry/HoneyDrunk.Telemetry.Sink.Sentry.csproj
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Sentry/HoneyDrunk.Telemetry.Sink.Sentry.csproj
@@ -34,7 +34,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="HoneyDrunk.Vault" Version="0.7.0" />
+    <PackageReference Include="HoneyDrunk.Vault" Version="0.8.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />

--- a/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Tempo/HoneyDrunk.Telemetry.Sink.Tempo.csproj
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Telemetry.Sink.Tempo/HoneyDrunk.Telemetry.Sink.Tempo.csproj
@@ -34,7 +34,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="HoneyDrunk.Vault" Version="0.7.0" />
+    <PackageReference Include="HoneyDrunk.Vault" Version="0.8.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />

--- a/HoneyDrunk.Pulse/Pulse.Collector/HoneyDrunk.Pulse.Collector.csproj
+++ b/HoneyDrunk.Pulse/Pulse.Collector/HoneyDrunk.Pulse.Collector.csproj
@@ -24,10 +24,10 @@
     <PackageReference Include="HoneyDrunk.Transport" Version="0.7.1" />
     <PackageReference Include="HoneyDrunk.Transport.AzureServiceBus" Version="0.7.1" />
     <PackageReference Include="HoneyDrunk.Transport.InMemory" Version="0.7.1" />
-    <PackageReference Include="HoneyDrunk.Vault" Version="0.7.0" />
-    <PackageReference Include="HoneyDrunk.Vault.EventGrid" Version="0.7.0" />
-    <PackageReference Include="HoneyDrunk.Vault.Providers.AppConfiguration" Version="0.7.0" />
-    <PackageReference Include="HoneyDrunk.Vault.Providers.AzureKeyVault" Version="0.7.0" />
+    <PackageReference Include="HoneyDrunk.Vault" Version="0.8.0" />
+    <PackageReference Include="HoneyDrunk.Vault.EventGrid" Version="0.8.0" />
+    <PackageReference Include="HoneyDrunk.Vault.Providers.AppConfiguration" Version="0.8.0" />
+    <PackageReference Include="HoneyDrunk.Vault.Providers.AzureKeyVault" Version="0.8.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
   </ItemGroup>

--- a/HoneyDrunk.Pulse/Pulse.Collector/Program.cs
+++ b/HoneyDrunk.Pulse/Pulse.Collector/Program.cs
@@ -23,7 +23,6 @@ using HoneyDrunk.Telemetry.Sink.Tempo.Extensions;
 using HoneyDrunk.Vault.EventGrid.Extensions;
 using HoneyDrunk.Vault.Providers.AppConfiguration.Extensions;
 using HoneyDrunk.Vault.Providers.AzureKeyVault.Extensions;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 
 namespace HoneyDrunk.Pulse.Collector;
@@ -49,7 +48,6 @@ public class Program
         var builder = WebApplication.CreateBuilder(args);
 
         builder.Configuration["HONEYDRUNK_NODE_ID"] ??= WellKnownNodes.Ops.Pulse.Value;
-        builder.Services.Replace(ServiceDescriptor.Singleton<IConfiguration>(builder.Configuration));
 
         builder.Services.AddHoneyDrunkNode(options =>
         {

--- a/HoneyDrunk.Pulse/Pulse.Collector/Program.cs
+++ b/HoneyDrunk.Pulse/Pulse.Collector/Program.cs
@@ -57,7 +57,7 @@ public class Program
             options.EnvironmentId = new EnvironmentId(builder.Environment.EnvironmentName.ToLowerInvariant());
         })
         .AddVaultWithAzureKeyVaultBootstrap()
-        .AddAppConfiguration();
+        .AddAppConfiguration(builder.Configuration);
 
         // Bind options once and register the same instance into DI (single source of truth)
         var collectorOptions = new PulseCollectorOptions();


### PR DESCRIPTION
## Summary
Adopt the **HoneyDrunk.Vault 0.8.0** `AddAppConfiguration(IConfigurationManager)` overload in `Pulse.Collector` (same pattern as Notify #58), replacing the defensive `Replace(ServiceDescriptor.Singleton<IConfiguration>(builder.Configuration))`.

The `Replace` turned out to be **load-bearing for the integration-test host**: `TransportPublishingIntegrationTests` run `Program.Main` through a test server where the default `IConfiguration` isn't the mutable `ConfigurationManager`, so the parameterless `AddAppConfiguration()` threw *"Development bootstrap requires a mutable IConfigurationManager"*. Passing `builder.Configuration` to the 0.8.0 overload fixes that for both the real and test hosts — and makes the `Replace` genuinely unnecessary.

## Changes
- Bump all `HoneyDrunk.Vault.*` references 0.7.0 → 0.8.0 (6 projects).
- `Pulse.Collector/Program.cs`: `.AddAppConfiguration(builder.Configuration)`; remove the `Replace(...)` + its now-unused `using`.

## Validation
- `dotnet build -c Release` — 0 errors.
- `TransportPublishingIntegrationTests` — **4/4 pass** (were failing on the first cut of this PR).
- `dotnet format --verify-no-changes` — clean.

Authorship: agent-claude-code
Out-of-band reason: Consumer cleanup following the HoneyDrunk.Vault 0.8.0 release; not a pre-scoped packet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)