### PR TITLE
docs: add root CHANGELOG and Pulse sample READMEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,61 @@
+# Changelog
+
+All notable changes to the HoneyDrunk.Pulse repository are documented here. The
+format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
+this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Per-package detail lives in each package's own `CHANGELOG.md` under
+`HoneyDrunk.Pulse/`.
+
+## Unreleased
+
+## 0.4.0 - Sonar + SAST cleanup
+
+### Added
+
+- Onboarded Pulse to SonarQube Cloud (ADR-0011 D11) with a `sonarcloud` job in `pr.yml` gating PRs on new-code findings and populating the main-branch dashboard.
+- Enabled the ADR-0086 Grid Review request workflow and the local Grid review worker.
+- Migrated the test suite to AwesomeAssertions and seeded the coverage baseline ratchet for the Grid PR coverage gate.
+
+### Changed
+
+- Hardened `Pulse.Collector` for Sonar findings: private `Program` constructor, static telemetry helpers, extracted magic-string constants, and reduced cognitive complexity in OTLP validation, enrichment, ingestion, and parsing paths.
+- Consolidated Loki, Mimir, and Tempo HTTP OTLP auth secret names behind a shared `HttpOtlpSinkAuthSecretNames` record and converted sink adapters to primary constructors.
+- Switched the sample apps to `await app.RunAsync()` / `await host.RunAsync()`.
+
+### Security
+
+- Hardened the `Pulse.Collector` Docker build context and `.dockerignore` to exclude secrets, dev settings, tests, samples, and repo docs (Sonar S6470).
+
+## 0.3.0 - Kernel adoption
+
+### Added
+
+- Added collector smoke tests pinning the default Node ID to the canonical Kernel well-known Pulse identity.
+- Added sink tests covering shared HTTP OTLP custom header, Basic auth, Authorization header, and retry behavior.
+
+### Changed
+
+- Adopted Kernel's canonical `WellKnownNodes.Ops.Pulse` fallback while preserving the `HONEYDRUNK_NODE_ID` override.
+- Aligned `HoneyDrunk.Kernel.Abstractions` to 0.7.0 and all package versions to 0.3.0 for the coordinated Kernel release.
+- Consolidated duplicated Loki, Mimir, and Tempo HTTP OTLP behavior behind a shared linked helper.
+
+## 0.2.0 - Vault + tenant context
+
+### Added
+
+- Added ADR-0026 tenant context propagation for collector ingress, analytics events, error reports, and low-cardinality collector telemetry tags.
+- Added a PostHog credential rotation canary covering per-flush Vault secret resolution.
+
+### Changed
+
+- Migrated the collector bootstrap to env-driven Azure Key Vault and Azure App Configuration discovery using the `pulse` label.
+- Registered the Vault Event Grid cache invalidation webhook at `/internal/vault/invalidate`.
+- Moved PostHog, Sentry, Loki, Tempo, and Mimir sink credentials behind `ISecretStore`.
+- Switched the deploy workflow to Azure OIDC.
+
+## 0.1.0 - Initial release
+
+### Added
+
+- First public release of the HoneyDrunk.Pulse telemetry ecosystem: telemetry abstractions, OpenTelemetry integration, the multi-backend sink pipeline (Loki, Tempo, Mimir, PostHog, Sentry, Azure Monitor), shared `PulseIngested` contracts, and the Pulse Collector OTLP receiver (HTTP + gRPC) with per-sink failure isolation.

--- a/HoneyDrunk.Pulse/HoneyDrunk.Pulse.Sample.Api/README.md
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Pulse.Sample.Api/README.md
@@ -23,5 +23,5 @@ dotnet run --project HoneyDrunk.Pulse/HoneyDrunk.Pulse.Sample.Api/HoneyDrunk.Pul
 Then send requests (see `HoneyDrunk.Pulse.Sample.Api.http`), e.g.:
 
 ```bash
-curl http://localhost:5xxx/weatherforecast
+curl http://localhost:5062/weatherforecast
 ```

--- a/HoneyDrunk.Pulse/HoneyDrunk.Pulse.Sample.Api/README.md
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Pulse.Sample.Api/README.md
@@ -1,0 +1,27 @@
+# HoneyDrunk.Pulse.Sample.Api
+
+A minimal ASP.NET Core sample that demonstrates HoneyDrunk telemetry in a web API.
+It wires up `AddHoneyDrunkOpenTelemetry` (traces, metrics, logs) and the Pulse
+analytics emitter, then exposes endpoints that exercise each path:
+
+- `GET /weatherforecast` — a traced success endpoint that tags the active activity.
+- `GET /error` — throws to show error/exception tracking.
+- `POST /analytics/feature-used` — emits a `TelemetryEvent` via `IAnalyticsEmitter` to the Pulse Collector.
+- `GET /health` — liveness probe.
+
+By default it ships traces to an OTLP endpoint at `http://localhost:4317` and
+analytics to a Pulse Collector at `http://localhost:5000`; override via
+`HoneyDrunk:OpenTelemetry:OtlpEndpoint` and `HoneyDrunk:Pulse:CollectorEndpoint`
+in configuration.
+
+## How to run
+
+```bash
+dotnet run --project HoneyDrunk.Pulse/HoneyDrunk.Pulse.Sample.Api/HoneyDrunk.Pulse.Sample.Api.csproj
+```
+
+Then send requests (see `HoneyDrunk.Pulse.Sample.Api.http`), e.g.:
+
+```bash
+curl http://localhost:5xxx/weatherforecast
+```

--- a/HoneyDrunk.Pulse/HoneyDrunk.Pulse.Sample.Worker/README.md
+++ b/HoneyDrunk.Pulse/HoneyDrunk.Pulse.Sample.Worker/README.md
@@ -1,0 +1,23 @@
+# HoneyDrunk.Pulse.Sample.Worker
+
+A minimal .NET Worker Service sample that demonstrates HoneyDrunk telemetry in a
+background processing loop. It wires up `AddHoneyDrunkOpenTelemetry` (traces,
+metrics, logs) and the Pulse analytics emitter, then runs a hosted `Worker` that:
+
+- Starts an `Activity` per simulated job and tags it with the job id and status.
+- Records a `sample.worker.jobs.processed` counter and a `sample.worker.job.duration` histogram.
+- Emits a `Worker.JobCompleted` `TelemetryEvent` via `IAnalyticsEmitter` to the Pulse Collector.
+- Logs success and failure paths via source-generated `LoggerMessage` methods.
+
+By default it ships traces to an OTLP endpoint at `http://localhost:4317` and
+analytics to a Pulse Collector at `http://localhost:5000`; override via
+`HoneyDrunk:OpenTelemetry:OtlpEndpoint` and `HoneyDrunk:Pulse:CollectorEndpoint`
+in configuration.
+
+## How to run
+
+```bash
+dotnet run --project HoneyDrunk.Pulse/HoneyDrunk.Pulse.Sample.Worker/HoneyDrunk.Pulse.Sample.Worker.csproj
+```
+
+The worker processes one job per second until stopped (Ctrl+C).

--- a/HoneyDrunk.Pulse/docs/examples/FILE_GUIDE.md
+++ b/HoneyDrunk.Pulse/docs/examples/FILE_GUIDE.md
@@ -366,11 +366,6 @@ Applications using HoneyDrunk.Web.Rest:
 
 ## 📖 Additional Resources
 
-### Official Documentation
-- [README.md](../README.md) - Project overview and quick start
-- [Abstractions README](../HoneyDrunk.Web.Rest.Abstractions/README.md) - Contracts documentation
-- [AspNetCore README](../HoneyDrunk.Web.Rest.AspNetCore/README.md) - Middleware documentation
-
 ### Related Projects
 - [HoneyDrunk.Kernel](https://github.com/HoneyDrunkStudios/HoneyDrunk.Kernel) - Core Grid primitives (optional integration)
 - [HoneyDrunk.Auth](https://github.com/HoneyDrunkStudios/HoneyDrunk.Auth) - Authentication and authorization (optional integration)


### PR DESCRIPTION
## Summary

Remediates the 2026-06-19 HoneyDrunk Docs Sync Report findings for HoneyDrunk.Pulse:

- **block** — Added a repository-root `CHANGELOG.md` in Keep a Changelog format, with `Unreleased` plus `0.4.0` / `0.3.0` / `0.2.0` / `0.1.0` sections derived from git tags, the existing per-package CHANGELOGs, and `git log`. Entries are factual; no fabricated dates (short labels used instead of dates).
- **block** — Added `HoneyDrunk.Pulse.Sample.Api/README.md` (sample app: what it demonstrates + `dotnet run --project ...`; Install omitted).
- **block** — Added `HoneyDrunk.Pulse.Sample.Worker/README.md` (sample app: what it demonstrates + `dotnet run --project ...`; Install omitted).
- **warn** — `docs/examples/FILE_GUIDE.md`: removed three dead local links (`../README.md`, `../HoneyDrunk.Web.Rest.Abstractions/README.md`, `../HoneyDrunk.Web.Rest.AspNetCore/README.md`) that pointed at non-existent HoneyDrunk.Web.Rest package READMEs. They do not correspond to the new Sample READMEs, so removal (not redirection) is the correct fix. The remaining sibling-doc links (`Architecture.md`, `Abstractions.md`, etc.) all resolve to existing files in `docs/examples/` and were left intact.

## Verification

- New Sample READMEs written from each project's `.csproj` + `Program.cs` (and `Worker.cs` for the worker); run command paths verified against the on-disk project files.
- `git grep` confirmed the three removed FILE_GUIDE links had no existing local targets; all other intra-doc links resolve locally.
- No `.cs` files modified; `dotnet format` not run (docs-only change).

Size justification: N/A

Authorship: agent-claude-code

Work Item: N/A
Out-of-band reason: Docs-sync remediation (2026-06-19 Docs Sync Report); mechanical doc-completeness/dead-link fix with no owning packet/work item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
